### PR TITLE
Remove unnecessary set INTERFACE_LINK_LIBRARIES

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
         cd ip
         mkdir build 
         cd build
-        cmake .. -DENABLE_TESTS=ON -DCMAKE_PREFIX_PATH="~/pfunit;~/"
+        cmake .. -DENABLE_TESTS=ON -DOPENMP=ON -DCMAKE_PREFIX_PATH="~/pfunit;~/"
         make -j2
     
     - name: test

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -9,7 +9,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 # ON/OFF implies ip was compiled with/without OPENMP
 if(@OPENMP@)
-  find_dependency(OpenMP)
+  find_dependency(OpenMP COMPONENTS Fortran)
 endif()
 
 get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4 IMPORTED_CONFIGURATIONS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ foreach(kind ${kinds})
   target_compile_definitions(${lib_name} PRIVATE "LSIZE=${kind_definition}")
   set_target_properties(${lib_name} PROPERTIES COMPILE_FLAGS "${BUILD_FLAGS}")
   set_target_properties(${lib_name} PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
-  set_target_properties(${lib_name} PROPERTIES INTERFACE_LINK_LIBRARIES ${lib_name})
+
   target_include_directories(${lib_name}
     PUBLIC $<BUILD_INTERFACE:${module_dir}>
     $<INSTALL_INTERFACE:include_${kind}>)


### PR DESCRIPTION
It doesn't do anything and overwrites things that should be in there like OpenMP