### PR TITLE
turn off latex build

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1682,7 +1682,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
Part of #86 

To eliminate this warning, turn off LATEX builds.

```
sh: 1: epstopdf: not found
error: Problems running epstopdf. Check your TeX installation!

```