### PR TITLE
Allow downstream packages to request shared or static library of package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" ON)
 option(BUILD_4 "Build the 4-byte real version of the library, libip_4.a" ON)
 option(BUILD_D "Build the 8-byte real version of the library, libip_d.a" ON)
+option(BUILD_TESTING "Build tests of the library" ON)
 
 # Figure whether user wants a _4, a _d, or both libraries.
 if(BUILD_4 AND BUILD_D)
@@ -46,18 +47,19 @@ endif()
 # We need the NCEPLIBS-sp library.
 find_package(sp 2.3.0 REQUIRED)
 
-# If doxygen documentation we enabled, build it.
-if(ENABLE_DOCS)
-  find_package(Doxygen REQUIRED)
-  set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
-  add_subdirectory(docs)  
-endif()
-
 # This is the source code directiroy.
 add_subdirectory(src)
 
 # Build tests.
-include(CTest)
 if(BUILD_TESTING)
-    add_subdirectory(tests)
+  include(CTest)
+  add_subdirectory(tests)
 endif()
+
+# If doxygen documentation we enabled, build it.
+if(ENABLE_DOCS)
+  find_package(Doxygen REQUIRED)
+  set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
+  add_subdirectory(docs)
+endif()
+

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,24 +1,48 @@
 @PACKAGE_INIT@
 
 #  * @PROJECT_NAME@::@PROJECT_NAME@_4 - real32 library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_8 - real64 library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_d - mixed precision library target
+#  * @PROJECT_NAME@::@PROJECT_NAME@_d - mixed library target
 
 # Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
-
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-config-version.cmake")
 include(CMakeFindDependencyMacro)
 
-# ON/OFF implies ip was compiled with/without OPENMP
 if(@OPENMP@)
-  find_dependency(OpenMP COMPONENTS Fortran)
+  find_dependency(OpenMP COMPONENT Fortran)
 endif()
 
-find_dependency(sp CONFIG)
+find_dependency(sp REQUIRED)
 
-get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4 IMPORTED_CONFIGURATIONS)
+# Initialize the static/shared builds of this library
+set(@PROJECT_NAME@_HAS_STATIC_LIBS OFF)
+if(@BUILD_STATIC_LIBS@)
+  set(@PROJECT_NAME@_HAS_STATIC_LIBS ON)
+endif()
+
+set(@PROJECT_NAME@_HAS_SHARED_LIBS OFF)
+if(@BUILD_SHARED_LIBS@)
+  set(@PROJECT_NAME@_HAS_SHARED_LIBS ON)
+endif()
+
+# By default, prefer to use STATIC libs
+# If the user wishes to use SHARED libs, they can do so by either:
+# 1. set(ip_USE_SHARED_LIBS ON) in their project, or
+# 2. -Dip_USE_SHARED_LIBS=ON during their project configuration
+if(@PROJECT_NAME@_USE_SHARED_LIBS)
+  # First check if @PROJECT_NAME@ was built with SHARED libs, if not, error out.
+  if(NOT @PROJECT_NAME@_HAS_SHARED_LIBS)
+    message(FATAL "@PROJECT_NAME@ was not built as a shared library, try static instead")
+  endif()
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_4 ALIAS @PROJECT_NAME@::@PROJECT_NAME@_4_shared)
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_d ALIAS @PROJECT_NAME@::@PROJECT_NAME@_d_shared)
+else()
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_4 ALIAS @PROJECT_NAME@::@PROJECT_NAME@_4_static)
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_d ALIAS @PROJECT_NAME@::@PROJECT_NAME@_d_static)
+endif()
 
 check_required_components("@PROJECT_NAME@")
 
 get_target_property(location @PROJECT_NAME@::@PROJECT_NAME@_4 LOCATION)
 message(STATUS "Found @PROJECT_NAME@: ${location} (found version \"@PROJECT_VERSION@\")")
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Mark Potts, Kyle Gerheiser, Ed Hartnett, Eric Engle
 
 # These are the source code filees.
-set(fortran_src gdswzd_c.F90 gdswzd_mod.F90 ip2lib_4.h 
+set(fortran_src gdswzd_c.F90 gdswzd_mod.F90 ip2lib_4.h
 ip2lib_d.h ipolates.F90 ipolatev.F90 ipxetas.F90 ipxwafs.F90
 ipxwafs2.F90 ipxwafs3.F90 movect.F90 bilinear_interp_mod.F90
 bicubic_interp_mod.F90 neighbor_interp_mod.F90 budget_interp_mod.F90
@@ -39,28 +39,24 @@ foreach(kind ${kinds})
   # Compiled with preprocessor definition LSIZE=D, not d
   string(TOUPPER ${kind} kind_definition)
 
-  set(BUILD_FLAGS "${fortran_${kind}_flags}")
-
   add_library(${lib_name}_objlib OBJECT ${fortran_src})
   if(BUILD_SHARED_LIBS)
     set_property(TARGET ${lib_name}_objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
   endif()
-  add_library(${PROJECT_NAME}::${lib_name} ALIAS ${lib_name}_objlib)
-
   target_compile_definitions(${lib_name}_objlib PRIVATE "LSIZE=${kind_definition}")
-  set_target_properties(${lib_name}_objlib PROPERTIES COMPILE_FLAGS "${BUILD_FLAGS}")
+  set_target_properties(${lib_name}_objlib PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
   set_target_properties(${lib_name}_objlib PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
-  target_include_directories(${lib_name}_objlib PUBLIC $<BUILD_INTERFACE:${module_dir}> $<INSTALL_INTERFACE:include_${kind}>)
+  target_include_directories(${lib_name}_objlib PRIVATE $<BUILD_INTERFACE:${module_dir}> $<INSTALL_INTERFACE:include_${kind}>)
 
   # Create static object library from object library.
   if(BUILD_STATIC_LIBS)
     add_library(${lib_name}_static STATIC $<TARGET_OBJECTS:${lib_name}_objlib>)
-    set_target_properties(${lib_name}_static PROPERTIES OUTPUT_NAME ${lib_name})
-    set_target_properties(${lib_name}_static PROPERTIES EXPORT_NAME ${lib_name})
-    set_target_properties(${lib_name}_static PROPERTIES EXPORT_NAME ${lib_name}_static)
+    add_library(${PROJECT_NAME}::${lib_name}_static ALIAS ${lib_name}_static)
+    target_include_directories(${lib_name}_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include_${kind}>)
+    target_include_directories(${lib_name}_static INTERFACE $<BUILD_INTERFACE:${module_dir}> $<INSTALL_INTERFACE:include_${kind}>)
     target_link_libraries(${lib_name}_static PUBLIC sp::sp_${kind})
     if(OpenMP_Fortran_FOUND)
-      target_link_libraries(${lib_name}_static PUBLIC OpenMP::OpenMP_Fortran)
+      target_link_libraries(${lib_name}_static PRIVATE OpenMP::OpenMP_Fortran)
     endif()
     list(APPEND LIB_TARGETS ${lib_name}_static)
   endif()
@@ -68,16 +64,17 @@ foreach(kind ${kinds})
   # Create shared object library from object library.
   if(BUILD_SHARED_LIBS)
     add_library(${lib_name}_shared SHARED $<TARGET_OBJECTS:${lib_name}_objlib>)
-    set_target_properties(${lib_name}_shared PROPERTIES OUTPUT_NAME ${lib_name})
-    set_target_properties(${lib_name}_shared PROPERTIES EXPORT_NAME ${lib_name})
+    add_library(${PROJECT_NAME}::${lib_name}_shared ALIAS ${lib_name}_shared)
     set_target_properties(${lib_name}_shared PROPERTIES SOVERSION 0)
+    target_include_directories(${lib_name}_shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include_${kind}>)
+    target_include_directories(${lib_name}_shared INTERFACE $<BUILD_INTERFACE:${module_dir}> $<INSTALL_INTERFACE:include_${kind}>)
     target_link_libraries(${lib_name}_shared PUBLIC sp::sp_${kind})
     if(OpenMP_Fortran_FOUND)
-      target_link_libraries(${lib_name}_shared PUBLIC OpenMP::OpenMP_Fortran)
+      target_link_libraries(${lib_name}_shared PRIVATE OpenMP::OpenMP_Fortran)
     endif()
     list(APPEND LIB_TARGETS ${lib_name}_shared)
   endif()
-  
+
   install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
   install(FILES ip2lib_${kind}.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind} RENAME ip2lib.h)
   install(FILES iplib_${kind}.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind} RENAME iplib.h)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,26 +24,26 @@ endif()
 if(BUILD_D)
   # Test earth_radius_mod.
   add_executable(test_earth_radius test_earth_radius.F90)
-  target_link_libraries(test_earth_radius PUBLIC ip::ip_d)
-  target_link_libraries(test_earth_radius PUBLIC sp::sp_d)
+  target_link_libraries(test_earth_radius PRIVATE ip::ip_d_static)
+  target_link_libraries(test_earth_radius PRIVATE sp::sp_d)
   add_test(test_earth_radius test_earth_radius)
-  
+
   # grib-2 tests
   add_library(test_library_grib2 input_data_mod_grib2.F90 interp_mod_grib2.F90)
-  target_link_libraries(test_library_grib2 PUBLIC ip::ip_d)
+  target_link_libraries(test_library_grib2 PUBLIC ip::ip_d_static)
   target_link_libraries(test_library_grib2 PUBLIC sp::sp_d)
-  
+
   add_executable(test_gdswzd_grib2 test_gdswzd_grib2.c)
   set_target_properties(test_gdswzd_grib2 PROPERTIES LINKER_LANGUAGE C)
   add_executable(test_scalar_grib2 test_scalar_grib2.F90)
   add_executable(test_vector_grib2 test_vector_grib2.F90)
-  
+
   target_link_libraries(test_gdswzd_grib2 PRIVATE test_library_grib2)
   target_link_libraries(test_scalar_grib2 PRIVATE test_library_grib2)
   target_link_libraries(test_vector_grib2 PRIVATE test_library_grib2)
-  
+
   add_test(test_gdswzd_c_grib2 test_gdswzd_grib2)
-  
+
   # scalar tests
   add_test(test_lambert_bilinear_scalar_grib2 test_scalar_grib2 218 0)
   add_test(test_gaussian_neighbor_scalar_grib2 test_scalar_grib2 127 2)
@@ -52,7 +52,7 @@ if(BUILD_D)
   add_test(test_polar-stereo_neighbor-budget_scalar_grib2 test_scalar_grib2 212 6)
   add_test(test_rotatedB_spectral_scalar_grib2 test_scalar_grib2 205 4)
   add_test(test_rotatedE_budget_scalar_grib2 test_scalar_grib2 203 3)
-  
+
   # # vector tests
   add_test(test_lambert_biliner_vector_grib2 test_vector_grib2 218 0)
   add_test(test_gaussian_neighbor_vector_grib2 test_vector_grib2 127 2)
@@ -61,22 +61,22 @@ if(BUILD_D)
   add_test(test_polar-stereo_neighbor-budget_vector_grib2 test_vector_grib2 212 6)
   add_test(test_rotatedB_spectral_vector_grib2 test_vector_grib2 205 4)
   add_test(test_rotatedE_budget_vector_grib2 test_vector_grib2 203 3)
-  
+
   # grib-1 tests
   add_library(test_library_grib1 input_data_mod_grib1.F90 interp_mod_grib1.F90)
-  target_link_libraries(test_library_grib1 PUBLIC ip::ip_d)
+  target_link_libraries(test_library_grib1 PUBLIC ip::ip_d_static)
   target_link_libraries(test_library_grib1 PUBLIC sp::sp_d)
-  
+
   add_executable(test_gdswzd_grib1 test_gdswzd_grib1.c)
   set_target_properties(test_gdswzd_grib1 PROPERTIES LINKER_LANGUAGE C)
   add_executable(test_scalar_grib1 test_scalar_grib1.F90)
   add_executable(test_vector_grib1 test_vector_grib1.F90)
-  
+
   target_link_libraries(test_scalar_grib1 PRIVATE test_library_grib1)
   target_link_libraries(test_vector_grib1 PRIVATE test_library_grib1)
-  target_link_libraries(test_gdswzd_grib1 ip::ip_d)
+  target_link_libraries(test_gdswzd_grib1 ip::ip_d_static)
   target_link_libraries(test_gdswzd_grib1 sp::sp_d)
-  
+
   add_test(test_gdswzd_c_grib1 test_gdswzd_grib1)
   add_test(test_lambert_bilinear_scalar_grib1 test_scalar_grib1 218 0)
   add_test(test_gaussian_neighbor_scalar_grib1 test_scalar_grib1 127 2)
@@ -85,7 +85,7 @@ if(BUILD_D)
   add_test(test_polar-stereo_neighbor-budget_scalar test_scalar_grib1 212 6)
   add_test(test_rotatedB_spectral_scalar test_scalar_grib1 205 4)
   add_test(test_rotatedE_budget_scalar_grib1 test_scalar_grib1 203 3)
-  
+
   # vector tests
   add_test(test_lambert_biliner_vector_grib1 test_vector_grib1 218 0)
   add_test(test_gaussian_neighbor_vector_grib1 test_vector_grib1 127 2)


### PR DESCRIPTION
This PR:
- allows downstream packages to find and use static (default) or dynamic version of the `ip` library.

If both types are built, static is preferred.

To request a shared type, the user can do either of the following in their project.
```
set(ip_USE_SHARED_LIBS ON)
```
or during configuration pass this option at the command line:
```
-Dip_USE_SHARED_LIBS=ON
```

See [this](https://github.com/NOAA-EMC/NCEPLIBS-sp/tree/feature/staticshared) branch in `NCEPlibs-sp` which allows the use of either `static` or `dynamic` `sp` library for use in this project.

