### PR TITLE
Fix warnings for tests

### DIFF
--- a/tests/input_data_mod_grib2.F90
+++ b/tests/input_data_mod_grib2.F90
@@ -20,7 +20,7 @@ module input_data_mod_grib2
   integer, public                :: input_gdtmpl(input_gdtlen)
   integer, public                :: vector_input_gdtmpl(input_gdtlen)
   
-  integer, parameter :: missing=b'11111111111111111111111111111111'
+  integer, parameter :: missing=4294967296
 
   real, allocatable, public      :: input_data(:,:)
   logical*1, allocatable, public :: input_bitmap(:,:)

--- a/tests/interp_mod_grib2.F90
+++ b/tests/interp_mod_grib2.F90
@@ -56,7 +56,7 @@ contains
     integer, allocatable      :: output_gdtmpl(:)
     integer                   :: ip, ipopt(20), output_gdtlen, output_gdtnum
     integer                   :: km, ibi(1), mi, iret, i, j
-    integer                   :: i_output, j_output, mo, no, ibo(1)
+    integer                   :: i_output=-1, j_output=-1, mo, no, ibo(1)
     integer                   :: num_pts_diff
     integer     , parameter   :: missing=4294967296
 

--- a/tests/interp_mod_grib2.F90
+++ b/tests/interp_mod_grib2.F90
@@ -396,7 +396,6 @@ contains
     real, allocatable         :: output_rlat(:), output_rlon(:)
     real, allocatable         :: output_crot(:), output_srot(:)
     real, allocatable         :: output_u_data(:,:), output_v_data(:,:)
-    real, allocatable         :: output_u_pt_data(:), output_v_pt_data(:), output_pt_bitmap(:)
     real                      :: avg_u_diff, avg_v_diff
     real                      :: max_u_diff, max_v_diff
     real(kind=4)              :: output_data4

--- a/tests/interp_mod_grib2.F90
+++ b/tests/interp_mod_grib2.F90
@@ -58,7 +58,7 @@ contains
     integer                   :: km, ibi(1), mi, iret, i, j
     integer                   :: i_output, j_output, mo, no, ibo(1)
     integer                   :: num_pts_diff
-    integer     , parameter   :: missing=b'11111111111111111111111111111111'
+    integer     , parameter   :: missing=4294967296
 
     logical*1, allocatable    :: output_bitmap(:,:)
 
@@ -389,7 +389,7 @@ contains
     integer                   :: km, ibi(1), mi, iret, i, j
     integer                   :: i_output, j_output, mo, no, ibo(1)
     integer                   :: num_upts_diff, num_vpts_diff
-    integer     , parameter   :: missing=b'11111111111111111111111111111111'
+    integer     , parameter   :: missing=4294967296
 
     logical*1, allocatable    :: output_bitmap(:,:)
 

--- a/tests/tst_gdswzd_grib1.c
+++ b/tests/tst_gdswzd_grib1.c
@@ -12,6 +12,9 @@
   Tests the mixed precision version of gdswzd.
 **************************************************************/
 
+void gdswzd_grib1(int *, int, int, double,
+         double *, double *, double *, double *, int *,
+         double *, double *, double *, double *, double *, double *, double *);
 
 int main()
 {


### PR DESCRIPTION
This PR cleans up various build warnings, so that running the make step no longer produces warnings for the tests.

Fixes #172, #108