### PR TITLE
Add Intel LLVM support

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -45,15 +45,15 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/sp
-        key: sp-${{ runner.os }}-Intel-${{ matrix.openmp }}-test
+        key: sp-${{ runner.os }}-Intel-${{ matrix.openmp }}-test-llvm
 
     - name: checkout-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
-        repository: NOAA-EMC/NCEPLIBS-sp
+        repository: AlexanderRichert-NOAA/NCEPLIBS-sp
         path: sp
-        ref: v2.3.3
+        ref: add_intel_llvm
 
     - name: build-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/sp
-        key: sp-${{ runner.os }}-Intel-${{ matrix.openmp }}-test-llvm
+        key: sp-${{ runner.os }}-Intel-${{ matrix.compilers }}-${{ matrix.openmp }}-alextest
 
     - name: checkout-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -25,9 +25,6 @@ jobs:
       matrix:
         openmp: [ ON, OFF ]
         compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
-        exclude:
-          - openmp: ON
-            compilers: "CC=icx FC=ifx"
 
     steps:
 

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -25,6 +25,9 @@ jobs:
       matrix:
         openmp: [ ON, OFF ]
         compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
+        exclude:
+          - openmp: ON
+            compilers: "CC=icx FC=ifx"
 
     steps:
 
@@ -37,7 +40,7 @@ jobs:
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        sudo apt-get install intel-oneapi-dev-utilities-2021.9.0 intel-oneapi-mpi-devel-2021.9.0 intel-oneapi-openmp-2023.1.0 intel-oneapi-compiler-fortran-2023.1.0 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.1.0
         echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
       
     - name: cache-sp
@@ -51,9 +54,9 @@ jobs:
       if: steps.cache-sp.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
-        repository: AlexanderRichert-NOAA/NCEPLIBS-sp
+        repository: NOAA-EMC/NCEPLIBS-sp
         path: sp
-        ref: add_intel_llvm
+        ref: v2.3.3
 
     - name: build-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -40,7 +40,7 @@ jobs:
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install intel-oneapi-dev-utilities-2021.9.0 intel-oneapi-mpi-devel-2021.9.0 intel-oneapi-openmp-2023.1.0 intel-oneapi-compiler-fortran-2023.1.0 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.1.0
+        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
       
     - name: cache-sp

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -1,6 +1,6 @@
 # This is a CI workflow for the NCEPLIBS-ip project.
 #
-# This workflow builds with the Intel compiler.
+# This workflow builds with the Intel Classic and OneAPI compilers.
 #
 # Ed Hartnett, 1/8/23
 name: Intel
@@ -21,13 +21,10 @@ defaults:
 jobs:
   Intel:
     runs-on: ubuntu-latest
-    env:
-      CC: icc
-      FC: ifort
-      CXX: icpc
     strategy:
       matrix:
         openmp: [ ON, OFF ]
+        compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
 
     steps:
 
@@ -64,7 +61,7 @@ jobs:
         cd sp
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/sp -DOPENMP=${{ matrix.openmp}} ..
+        ${{ matrix.compilers }} cmake -DCMAKE_INSTALL_PREFIX=~/sp -DOPENMP=${{ matrix.openmp}} ..
         make -j2
         make install
 
@@ -78,7 +75,7 @@ jobs:
         cd ip
         mkdir build 
         cd build
-        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=OFF -DCMAKE_PREFIX_PATH="~/sp" ..
+        ${{ matrix.compilers }} cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=OFF -DCMAKE_PREFIX_PATH="~/sp" ..
         make -j2 VERBOSE=1
     
     - name: test

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -45,15 +45,15 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/sp
-        key: sp-${{ runner.os }}-Intel-${{ matrix.openmp }}-2.3.3-1
+        key: sp-${{ runner.os }}-Intel-${{ matrix.openmp }}-test
 
     - name: checkout-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
-        repository: NOAA-EMC/NCEPLIBS-sp
+        repository: AlexanderRichert-NOAA/NCEPLIBS-sp
         path: sp
-        ref: v2.3.3
+        ref: add_intel_llvm
 
     - name: build-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -7,6 +7,11 @@ The NCEP general interpolation library (NCEPLIBS-ip) contains Fortran
 used at NCEP. The library is particularly efficient when interpolating
 many fields at one time.
 
+NCEPLIBS-ip supports compilation with the GNU Compiler Collection 
+(gfortran), Intel Classic (ifort), and Intel LLVM (ifx) compilers.
+In the case of Intel LLVM, it is recommended to use at least version
+2023.2.1 to avoid any number of compiler issues.
+
 ## Interpolation
 
 There are currently six interpolation methods available in the

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,7 +8,7 @@ used at NCEP. The library is particularly efficient when interpolating
 many fields at one time.
 
 NCEPLIBS-ip supports compilation with the GNU Compiler Collection 
-(gfortran), Intel Classic (ifort), and Intel LLVM (ifx) compilers.
+(gfortran), Intel Classic (ifort), and Intel OneAPI (ifx) compilers.
 In the case of Intel LLVM, it is recommended to use at least version
 2023.2.1 to avoid any number of compiler issues.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ constants_mod.F90 ip_grids_mod.F90 ip_grid_factory_mod.F90
 ip_interpolators_mod.F90 earth_radius_mod.F90 polfix_mod.F90)
 
 # Set compiler flags.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS "-g -traceback -warn all -auto -convert big_endian -assume byterecl -fp-model strict -fpp ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -warn all")
   set(fortran_d_flags "-r8")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ execute_process(COMMAND cmake -E create_symlink
   )
 
 # Set compiler flags for intel.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS "-r8 -g -traceback -check all -warn all -heap-arrays -assume byterecl ${CMAKE_Fortran_FLAGS} ")
   set(CMAKE_C_FLAGS "-std=c99")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,9 +10,10 @@ execute_process(COMMAND cmake -E create_symlink
 
 # Set compiler flags for intel.
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
-  set(CMAKE_Fortran_FLAGS "-r8 -g -traceback -warn all -heap-arrays -assume byterecl -nocheck ${CMAKE_Fortran_FLAGS} ")
-  if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-    set(CMAKE_Fortran_FLAGS "-check all ${CMAKE_Fortran_FLAGS} ")
+  set(CMAKE_Fortran_FLAGS "-r8 -g -check all -traceback -warn all -heap-arrays -assume byterecl ${CMAKE_Fortran_FLAGS} ")
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "^(IntelLLVM)$")
+    # Avoid Intel OneAPI 2023.2.1 bug
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -check nouninit ")
   endif()
   set(CMAKE_C_FLAGS "-std=c99")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,10 @@ execute_process(COMMAND cmake -E create_symlink
 
 # Set compiler flags for intel.
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
-  set(CMAKE_Fortran_FLAGS "-r8 -g -traceback -check all -warn all -heap-arrays -assume byterecl ${CMAKE_Fortran_FLAGS} ")
+  set(CMAKE_Fortran_FLAGS "-r8 -g -traceback -warn all -heap-arrays -assume byterecl -nocheck ${CMAKE_Fortran_FLAGS} ")
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+    set(CMAKE_Fortran_FLAGS "-check all ${CMAKE_Fortran_FLAGS} ")
+  endif()
   set(CMAKE_C_FLAGS "-std=c99")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fno-range-check -g -fbacktrace -fcheck=all -Wall -O0 -fimplicit-none -Wsurprising -Wextra ${CMAKE_Fortran_FLAGS} ")


### PR DESCRIPTION
This PR adds support for Intel LLVM compilers (icx/ifx).

Fixes #142

Waiting for https://github.com/NOAA-EMC/NCEPLIBS-sp/pull/114 then will change sp ref in Intel CI to appropriate commit hash

Update required test settings after approval