### PR TITLE
In intel CI, use NOAA-EMC sp

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -51,9 +51,9 @@ jobs:
       if: steps.cache-sp.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
-        repository: AlexanderRichert-NOAA/NCEPLIBS-sp
+        repository: NOAA-EMC/NCEPLIBS-sp
         path: sp
-        ref: add_intel_llvm
+        ref: develop
 
     - name: build-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/sp
-        key: sp-${{ runner.os }}-Intel-${{ matrix.compilers }}-${{ matrix.openmp }}-alextest
+        key: sp-${{ runner.os }}-Intel-${{ matrix.compilers }}-${{ matrix.openmp }}
 
     - name: checkout-sp
       if: steps.cache-sp.outputs.cache-hit != 'true'


### PR DESCRIPTION
I forgot to revert back to using NOAA-EMC/NCEPLIBS-sp (rather than my fork) after adding Intel LLVM support.

squash-n-merge