### PR TITLE
Reorganize compiler flags & update code to eliminate warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(GNUInstallDirs)
 
 # Handle user options.
 option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
-option(OPENMP "use OpenMP threading" OFF)
+option(OPENMP "Use OpenMP threading" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(BUILD_4 "Build the 4-byte real version of the library, libip_4.a" ON)
 option(BUILD_D "Build the 8-byte real version of the library, libip_d.a" ON)
@@ -45,6 +45,21 @@ endif()
 
 # We need the NCEPLIBS-sp library.
 find_package(sp 2.3.0 REQUIRED)
+
+# Set compiler flags.
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
+  set(CMAKE_Fortran_FLAGS "-g -traceback -assume byterecl -fp-model strict -fpp -auto ${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -warn all")
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "^(IntelLLVM)$")
+    # Avoid Intel OneAPI 2023.2.1 bug
+    set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check nouninit ")
+  endif()
+  set(fortran_d_flags "-r8")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
+  set(CMAKE_Fortran_FLAGS "-g -fbacktrace -cpp -fimplicit-none ${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ggdb -Wall -Wno-unused-dummy-argument -Wsurprising -Wextra -fcheck=all")
+  set(fortran_d_flags "-fdefault-real-8")
+endif()
 
 # This is the source code directiroy.
 add_subdirectory(src)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -929,7 +929,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = tinyreal
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,17 +16,6 @@ ip_rot_equid_cylind_egrid_mod.F90 ip_rot_equid_cylind_grid_mod.F90
 constants_mod.F90 ip_grids_mod.F90 ip_grid_factory_mod.F90
 ip_interpolators_mod.F90 earth_radius_mod.F90 polfix_mod.F90)
 
-# Set compiler flags.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
-  set(CMAKE_Fortran_FLAGS "-g -traceback -warn all -auto -convert big_endian -assume byterecl -fp-model strict -fpp ${CMAKE_Fortran_FLAGS}")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check all -warn all")
-  set(fortran_d_flags "-r8")
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
-  set(CMAKE_Fortran_FLAGS "-g  -fbacktrace -fconvert=big-endian -cpp ${CMAKE_Fortran_FLAGS}")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -ggdb -Wall -fcheck=all")
-  set(fortran_d_flags "-fdefault-real-8")
-endif()
-
 # We build a version of the library with 4-byte reals (_4), and one
 # with 8-byte reals (_d).
 foreach(kind ${kinds})

--- a/src/bicubic_interp_mod.F90
+++ b/src/bicubic_interp_mod.F90
@@ -19,6 +19,9 @@ module bicubic_interp_mod
      module procedure interpolate_bicubic_vector
   end interface interpolate_bicubic
 
+  ! Smallest positive real value (use for equality comparisons)
+  REAL :: TINYREAL=TINY(1.0)
+
 contains
 
   !> This subprogram performs bicubic interpolation
@@ -174,7 +177,7 @@ contains
              RLATX(N)=RLAT(N)
              XIJ=XPTS(N)
              YIJ=YPTS(N)
-             IF(XIJ.NE.FILL.AND.YIJ.NE.FILL) THEN
+             IF(ABS(XIJ-FILL).GT.TINYREAL.AND.ABS(YIJ-FILL).GT.TINYREAL) THEN
                 IJX(1:4)=FLOOR(XIJ-1)+(/0,1,2,3/)
                 IJY(1:4)=FLOOR(YIJ-1)+(/0,1,2,3/)
                 XF=XIJ-IJX(2)
@@ -439,7 +442,7 @@ contains
              SROTX(N)=SROT(N)
              XIJ=XPTS(N)
              YIJ=YPTS(N)
-             IF(XIJ.NE.FILL.AND.YIJ.NE.FILL) THEN
+             IF(ABS(XIJ-FILL).GT.TINYREAL.AND.ABS(YIJ-FILL).GT.TINYREAL) THEN
                 IJX(1:4)=FLOOR(XIJ-1)+(/0,1,2,3/)
                 IJY(1:4)=FLOOR(YIJ-1)+(/0,1,2,3/)
                 XF=XIJ-IJX(2)

--- a/src/bilinear_interp_mod.F90
+++ b/src/bilinear_interp_mod.F90
@@ -21,6 +21,9 @@ module bilinear_interp_mod
      module procedure interpolate_bilinear_vector
   end interface interpolate_bilinear
 
+  ! Smallest positive real value (use for equality comparisons)
+  REAL :: TINYREAL=TINY(1.0)
+
 contains
 
   !> This subprogram performs bilinear interpolation
@@ -165,7 +168,7 @@ contains
              RLATX(N)=RLAT(N)
              XIJ=XPTS(N)
              YIJ=YPTS(N)
-             IF(XIJ.NE.FILL.AND.YIJ.NE.FILL) THEN
+             IF(ABS(XIJ-FILL).GT.TINYREAL.AND.ABS(YIJ-FILL).GT.TINYREAL) THEN
                 IJX(1:2)=FLOOR(XIJ)+(/0,1/)
                 IJY(1:2)=FLOOR(YIJ)+(/0,1/)
                 XF=XIJ-IJX(1)
@@ -217,7 +220,7 @@ contains
           LO(N,K)=W.GE.PMP
           IF(LO(N,K)) THEN
              GO(N,K)=G/W
-          ELSEIF(MSPIRAL.GT.0.AND.XPTS(N).NE.FILL.AND.YPTS(N).NE.FILL) THEN
+          ELSEIF(MSPIRAL.GT.0.AND.ABS(XPTS(N)-FILL).GT.TINYREAL.AND.ABS(YPTS(N)-FILL).GT.TINYREAL) THEN
              I1=NINT(XPTS(N))
              J1=NINT(YPTS(N))
              IXS=INT(SIGN(1.,XPTS(N)-I1))
@@ -429,7 +432,7 @@ contains
              SROTX(N)=SROT(N)
              XIJ=XPTS(N)
              YIJ=YPTS(N)
-             IF(XIJ.NE.FILL.AND.YIJ.NE.FILL) THEN
+             IF(ABS(XIJ-FILL).GT.TINYREAL.AND.ABS(YIJ-FILL).GT.TINYREAL) THEN
                 IJX(1:2)=FLOOR(XIJ)+(/0,1/)
                 IJY(1:2)=FLOOR(YIJ)+(/0,1/)
                 XF=XIJ-IJX(1)

--- a/src/budget_interp_mod.F90
+++ b/src/budget_interp_mod.F90
@@ -23,6 +23,9 @@ module budget_interp_mod
      module procedure interpolate_budget_vector
   end interface interpolate_budget
 
+  ! Smallest positive real value (use for equality comparisons)
+  REAL :: TINYREAL=TINY(1.0)
+
 contains
 
   !> Performs budget interpolation from any grid to any grid (or to
@@ -195,7 +198,7 @@ contains
        ELSEIF(LSW.EQ.1) THEN
           WB=IPOPT(2+LB)
        ENDIF
-       IF(WB.NE.0) THEN
+       IF(ABS(WB).GT.TINYREAL) THEN
           !$OMP PARALLEL DO PRIVATE(N) SCHEDULE(STATIC)
           DO N=1,NO
              XPTB(N)=XPTS(N)+IB*RB2
@@ -214,7 +217,7 @@ contains
           DO N=1,NO
              XI=XPTB(N)
              YI=YPTB(N)
-             IF(XI.NE.FILL.AND.YI.NE.FILL) THEN
+             IF(ABS(XI-FILL).GT.TINYREAL.AND.ABS(YI-FILL).GT.TINYREAL) THEN
                 I1=INT(XI)
                 I2=I1+1
                 J1=INT(YI)
@@ -556,7 +559,7 @@ contains
        ELSEIF(IPOPT(2).NE.-1) THEN
           WB=IPOPT(2+LB)
        ENDIF
-       IF(WB.NE.0) THEN
+       IF(ABS(WB).GT.TINYREAL) THEN
           !$OMP PARALLEL DO PRIVATE(N) SCHEDULE(STATIC)
           DO N=1,NO
              XPTB(N)=XPTS(N)+IB*RB2
@@ -576,7 +579,7 @@ contains
           DO N=1,NO
              XI=XPTB(N)
              YI=YPTB(N)
-             IF(XI.NE.FILL.AND.YI.NE.FILL) THEN
+             IF(ABS(XI-FILL).GT.TINYREAL.AND.ABS(YI-FILL).GT.TINYREAL) THEN
                 I1=INT(XI)
                 I2=I1+1
                 WI2=XI-I1

--- a/src/ip_polar_stereo_grid_mod.F90
+++ b/src/ip_polar_stereo_grid_mod.F90
@@ -49,6 +49,7 @@ module ip_polar_stereo_grid_mod
   REAL :: RERTH !< Radius of the Earth.
   REAL :: H !< Local copy of h.
   REAL :: ORIENT !< Local copy of orient.
+  REAL :: TINYREAL=TINY(1.0) !< Smallest positive real value (use for equality comparisons)
 
 CONTAINS
 
@@ -102,7 +103,7 @@ CONTAINS
       HI=(-1.)**ISCAN
       HJ=(-1.)**(1-JSCAN)
 
-      IF(self%H.EQ.-1)self%ORIENT=self%ORIENT+180.
+      IF(ABS(self%H+1.).LT.TINYREAL) self%ORIENT=self%ORIENT+180.
 
       self%DXS=DX*HI
       self%DYS=DY*HJ
@@ -405,8 +406,8 @@ CONTAINS
        IF(.NOT.ELLIPTICAL)THEN
           !$OMP PARALLEL DO PRIVATE(N,DR,DR2) REDUCTION(+:NRET) SCHEDULE(STATIC)
           DO N=1,NPTS
-             IF(ABS(RLON(N)).LE.360.AND.ABS(RLAT(N)).LE.90.AND. &
-                  H*RLAT(N).NE.-90) THEN
+             IF(ABS(RLON(N)).LT.(360.+TINYREAL).AND.ABS(RLAT(N)).LT.(90.+TINYREAL).AND. &
+                  ABS(H*RLAT(N)+90).GT.TINYREAL) THEN
                 DR=DE*TAN((90-H*RLAT(N))/2/DPR)
                 DR2=DR**2
                 XPTS(N)=XP+H*SIN((RLON(N)-ORIENT)/DPR)*DR/DXS
@@ -431,8 +432,8 @@ CONTAINS
        ELSE  ! ELLIPTICAL CASE
           !$OMP PARALLEL DO PRIVATE(N,ALAT,ALONG,T,RHO) REDUCTION(+:NRET) SCHEDULE(STATIC)
           DO N=1,NPTS
-             IF(ABS(RLON(N)).LE.360.AND.ABS(RLAT(N)).LE.90.AND.  &
-                  H*RLAT(N).NE.-90) THEN
+             IF(ABS(RLON(N)).LT.(360+TINYREAL).AND.ABS(RLAT(N)).LT.(90+TINYREAL).AND.  &
+                  ABS(H*RLAT(N)+90).GT.TINYREAL) THEN
                 ALAT = H*RLAT(N)/DPR
                 ALONG = (RLON(N)-ORIENT)/DPR
                 T=TAN(PI4-ALAT*0.5)/((1.-E*SIN(ALAT))/  &

--- a/src/neighbor_budget_interp_mod.F90
+++ b/src/neighbor_budget_interp_mod.F90
@@ -19,6 +19,9 @@ module neighbor_budget_interp_mod
      module procedure interpolate_neighbor_budget_vector
   end interface interpolate_neighbor_budget
 
+  ! Smallest positive real value (use for equality comparisons)
+  REAL :: TINYREAL=TINY(1.0)
+
 contains
 
   !> Interpolate scalar fields (budget).
@@ -189,7 +192,7 @@ contains
        LB=MAX(ABS(IB),ABS(JB))
        WB=1
        IF(LSW.EQ.1) WB=IPOPT(2+LB)
-       IF(WB.NE.0) THEN
+       IF(ABS(WB).GT.TINYREAL) THEN
           DO N=1,NO
              XPTB(N)=XPTS(N)+IB/REAL(NB2)
              YPTB(N)=YPTS(N)+JB/REAL(NB2)
@@ -205,7 +208,7 @@ contains
           DO N=1,NO
              XI=XPTB(N)
              YI=YPTB(N)
-             IF(XI.NE.FILL.AND.YI.NE.FILL) THEN
+             IF(ABS(XI-FILL).GT.TINYREAL.AND.ABS(YI-FILL).GT.TINYREAL) THEN
                 I1=NINT(XI)
                 J1=NINT(YI)
                 N11(N)=grid_in%field_pos(i1, j1)
@@ -470,7 +473,7 @@ contains
        LB=MAX(ABS(IB),ABS(JB))
        WB=1
        IF(LSW.EQ.1) WB=IPOPT(2+LB)
-       IF(WB.NE.0) THEN
+       IF(ABS(WB).GT.TINYREAL) THEN
           DO N=1,NO
              XPTB(N)=XPTS(N)+IB/REAL(NB2)
              YPTB(N)=YPTS(N)+JB/REAL(NB2)
@@ -486,7 +489,7 @@ contains
           DO N=1,NO
              XI=XPTB(N)
              YI=YPTB(N)
-             IF(XI.NE.FILL.AND.YI.NE.FILL) THEN
+             IF(ABS(XI-FILL).GT.TINYREAL.AND.ABS(YI-FILL).GT.TINYREAL) THEN
                 I1=NINT(XI)
                 J1=NINT(YI)
                 N11(N)=grid_in%field_pos(i1, j1)

--- a/src/neighbor_interp_mod.F90
+++ b/src/neighbor_interp_mod.F90
@@ -31,6 +31,9 @@ module neighbor_interp_mod
      module procedure interpolate_neighbor_vector
   end interface interpolate_neighbor
 
+  ! Smallest positive real value (use for equality comparisons)
+  REAL :: TINYREAL=TINY(1.0)
+
 contains
 
   !> Interpolate scalar fields (neighbor).
@@ -185,7 +188,7 @@ contains
              RLATX(N)=RLAT(N)
              XPTSX(N)=XPTS(N)
              YPTSX(N)=YPTS(N)
-             IF(XPTS(N).NE.FILL.AND.YPTS(N).NE.FILL) THEN
+             IF(ABS(XPTS(N)-FILL).GT.TINYREAL.AND.ABS(YPTS(N)-FILL).GT.TINYREAL) THEN
                 nxy(n) = grid_in%field_pos(NINT(XPTS(N)), NINT(YPTS(N)))
              ELSE
                 NXY(N)=0
@@ -449,7 +452,7 @@ contains
              YPTSX(N)=YPTS(N)
              CROTX(N)=CROT(N)
              SROTX(N)=SROT(N)
-             IF(XPTS(N).NE.FILL.AND.YPTS(N).NE.FILL) THEN
+             IF(ABS(XPTS(N)-FILL).GT.TINYREAL.AND.ABS(YPTS(N)-FILL).GT.TINYREAL) THEN
                 nxy(n) = grid_in%field_pos(NINT(XPTS(N)),NINT(YPTS(N)))
                 IF(NXY(N).GT.0) THEN
                    CALL MOVECT(RLAI(NXY(N)),RLOI(NXY(N)),RLAT(N),RLON(N),CM,SM)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,16 +8,13 @@ execute_process(COMMAND cmake -E create_symlink
   "${CMAKE_CURRENT_BINARY_DIR}/data" # New name
   )
 
-# Set compiler flags for intel.
+# Set compiler flags.
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_DEBUG}")
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
-  set(CMAKE_Fortran_FLAGS "-r8 -g -check all -traceback -warn all -heap-arrays -assume byterecl ${CMAKE_Fortran_FLAGS} ")
-  if(CMAKE_Fortran_COMPILER_ID MATCHES "^(IntelLLVM)$")
-    # Avoid Intel OneAPI 2023.2.1 bug
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -check nouninit ")
-  endif()
+  set(CMAKE_Fortran_FLAGS "-r8 -heap-arrays ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_C_FLAGS "-std=c99")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
-  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fno-range-check -g -fbacktrace -fcheck=all -Wall -O0 -fimplicit-none -Wsurprising -Wextra ${CMAKE_Fortran_FLAGS} ")
+  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 ${CMAKE_Fortran_FLAGS}")
 endif()
 
 # Set compiler flags for GNU.

--- a/tests/input_data_mod_grib2.F90
+++ b/tests/input_data_mod_grib2.F90
@@ -27,7 +27,7 @@ module input_data_mod_grib2
   integer, public                :: input_gdtmpl(input_gdtlen)
   integer, public                :: vector_input_gdtmpl(input_gdtlen)
   
-  integer, parameter :: missing=4294967296
+  integer, parameter :: missing=huge(1)
 
   real(KIND=REALSIZE), allocatable, public      :: input_data(:,:)
   real(KIND=REALSIZE), allocatable, public      :: input_u_data(:,:)


### PR DESCRIPTION
This PR reorganizes the CMakeLists.txt's to consolidate compiler flags as much as possible into the root CMakeLists.txt.

I've gone the route of disabling the warnings for unused dummy arguments (#183). The alternative is to insert dummy code so that those variables get "used," but I'm not sure it's worth cluttering up the code.

The O0 flag is now being used for running the tests, which makes them run slower but otherwise no issues.

I want to do a bit further testing (i.e., with a "real" application) on account of the changes related to real comparison and the use of TINYREAL.

Fixes #161, #183, #187