### PR TITLE
Change constants_mod -> ip_constants_mod

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ ip_station_points_grid_mod.F90 ip_gaussian_grid_mod.F90
 ip_equid_cylind_grid_mod.F90 ip_lambert_conf_grid_mod.F90
 ip_mercator_grid_mod.F90 ip_polar_stereo_grid_mod.F90
 ip_rot_equid_cylind_egrid_mod.F90 ip_rot_equid_cylind_grid_mod.F90
-constants_mod.F90 ip_grids_mod.F90 ip_grid_factory_mod.F90
+ip_constants_mod.F90 ip_grids_mod.F90 ip_grid_factory_mod.F90
 ip_interpolators_mod.F90 earth_radius_mod.F90 polfix_mod.F90)
 
 # Build _4, _d, and/or _8 depending on options provided to CMake

--- a/src/ip_constants_mod.F90
+++ b/src/ip_constants_mod.F90
@@ -6,7 +6,7 @@
 !> @brief Module containing common constants.
 !!
 !! @author Kyle Gerheiser, George Gayno, Alex Richert
-module constants_mod
+module ip_constants_mod
   implicit none
 
   public
@@ -18,5 +18,5 @@ module constants_mod
   real, parameter :: RERTH_WGS84=6.378137E6 !< Radius of the Earth defined by WGS-84
   real, parameter :: E2_WGS84 = 0.00669437999013 !< Eccentricity squared of Earth defined by WGS-84
   
-end module constants_mod
+end module ip_constants_mod
 

--- a/src/ip_gaussian_grid_mod.F90
+++ b/src/ip_gaussian_grid_mod.F90
@@ -15,7 +15,7 @@ module ip_gaussian_grid_mod
   use ip_grid_descriptor_mod
   use ip_grid_mod
   use earth_radius_mod
-  use constants_mod
+  use ip_constants_mod
   implicit none
 
   private

--- a/src/ip_lambert_conf_grid_mod.F90
+++ b/src/ip_lambert_conf_grid_mod.F90
@@ -15,7 +15,7 @@ module ip_lambert_conf_grid_mod
   use ip_grid_descriptor_mod
   use ip_grid_mod
   use earth_radius_mod
-  use constants_mod
+  use ip_constants_mod
   implicit none
 
   private

--- a/src/ip_mercator_grid_mod.F90
+++ b/src/ip_mercator_grid_mod.F90
@@ -12,7 +12,7 @@
 module ip_mercator_grid_mod
   use ip_grid_descriptor_mod
   use ip_grid_mod
-  use constants_mod, only: DPR, PI
+  use ip_constants_mod, only: DPR, PI
   use earth_radius_mod
   implicit none
 

--- a/src/ip_polar_stereo_grid_mod.F90
+++ b/src/ip_polar_stereo_grid_mod.F90
@@ -13,7 +13,7 @@
 module ip_polar_stereo_grid_mod
   use ip_grid_descriptor_mod
   use ip_grid_mod
-  use constants_mod, only: DPR, PI, PI2, PI4, RERTH_WGS84, E2_WGS84
+  use ip_constants_mod, only: DPR, PI, PI2, PI4, RERTH_WGS84, E2_WGS84
   use earth_radius_mod
   implicit none
 

--- a/src/ip_rot_equid_cylind_egrid_mod.F90
+++ b/src/ip_rot_equid_cylind_egrid_mod.F90
@@ -25,7 +25,7 @@ module ip_rot_equid_cylind_egrid_mod
   use iso_fortran_env, only: real64
   use ip_grid_descriptor_mod
   use ip_grid_mod
-  use constants_mod, only: DPR, PI
+  use ip_constants_mod, only: DPR, PI
   use earth_radius_mod
   implicit none
 

--- a/src/ip_rot_equid_cylind_grid_mod.F90
+++ b/src/ip_rot_equid_cylind_grid_mod.F90
@@ -20,7 +20,7 @@ module ip_rot_equid_cylind_grid_mod
   use iso_fortran_env, only: real64
   use ip_grid_descriptor_mod
   use ip_grid_mod
-  use constants_mod, only: DPR, PI
+  use ip_constants_mod, only: DPR, PI
   use earth_radius_mod
   implicit none
 


### PR DESCRIPTION
This PR renames 'constants_mod' to 'ip_constants_mod' to deconflict with other packages, namely FMS (which is used throughout ufs_utils, UFS WM, ...). Thankfully very few packages have been updated to use ip 4.x, and the ones that have do not use ip's constants_mod.

Fixes #197