### PR TITLE
add switch for two different init_grib2 approaches for non-E arakawa grids

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -35,7 +35,7 @@ jobs:
         cd ip
         mkdir build 
         cd build
-        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} -DCMAKE_INSTALL_PREFIX=~/install -DBUILD_8=ON ..
+        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=~/install -DBUILD_8=ON ..
         make -j2 VERBOSE=2
         make install
         ls -l ~/install

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -42,7 +42,7 @@ jobs:
         spack develop --no-clone --path $GITHUB_WORKSPACE/ip ip@develop
         spack add ip@develop%gcc@11 ${{ matrix.variants }} target=x86_64
         precision=$(echo ${{ matrix.variants }} | grep -oP " precision=\K[4d8]")
-        if [ "$precision" == "d" ]; then spack add grib-util@develop +tests ; fi
+        if [ "$precision" == "d" ]; then spack add grib-util@develop +tests ^g2c +build_v2_api ; fi
         spack external find cmake gmake
         spack external find --path /usr/lib/x86_64-linux-gnu/openblas-serial openblas
         spack config add "packages:lapack:buildable:false"

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -55,6 +55,15 @@ jobs:
         libvar=IP_LIB${precision}
         ls ${!libvar} | grep -cE "/libip_${precision}\."$suffix'$'
 
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.variants }}
+        path: |
+          ${{ github.workspace }}/*/spack-build-*/Testing/Temporary/LastTest.log
+          /tmp/runner/spack-stage/spack-stage-*/install-time-test-log.txt
+
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.variants }}
         path: |
-          ${{ github.workspace }}/*/spack-build-*/Testing/Temporary/LastTest.log
+          /tmp/runner/spack-stage/spack-stage-*/spack-build-*/Testing/Temporary/LastTest.log
           /tmp/runner/spack-stage/spack-stage-*/install-time-test-log.txt
 
   # This job validates the Spack recipe by making sure each cmake build option is represented

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -42,7 +42,7 @@ jobs:
         spack develop --no-clone --path $GITHUB_WORKSPACE/ip ip@develop
         spack add ip@develop%gcc@11 ${{ matrix.variants }} target=x86_64
         precision=$(echo ${{ matrix.variants }} | grep -oP " precision=\K[4d8]")
-        if [ "$precision" == "d" ]; then spack add grib-util@develop ; fi
+        if [ "$precision" == "d" ]; then spack add grib-util@develop +tests ; fi
         spack external find cmake gmake
         spack external find --path /usr/lib/x86_64-linux-gnu/openblas-serial openblas
         spack config add "packages:lapack:buildable:false"

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -35,6 +35,7 @@ module ip_grid_mod
   public :: gdswzd_interface
   public :: operator(==)
   public :: use_ncep_post_arakawa
+  public :: unuse_ncep_post_arakawa
 
   !> Abstract grid that holds fields and methods common to all grids.
   !! ip_grid is meant to be subclassed when implementing a new grid.
@@ -184,6 +185,16 @@ contains
   subroutine use_ncep_post_arakawa() bind(c)
     ncep_post_arakawa = .true.
   end subroutine use_ncep_post_arakawa
+
+  !> Disables ncep_post/wgrib2-compatible non-E Arakawa grib2 grids
+  !> by setting 'ncep_post_arakawa=.false.'.
+  !> This subroutine should be called prior to init_grib2().
+  !>
+  !> @author Alex Richert
+  !> @date May 2024
+  subroutine unuse_ncep_post_arakawa() bind(c)
+    ncep_post_arakawa = .false.
+  end subroutine unuse_ncep_post_arakawa
 
   !> Compares two grids.
   !>

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -28,7 +28,7 @@ module ip_grid_mod
   integer, public, parameter :: ROT_EQUID_CYLIND_E_GRID_ID_GRIB2 = 32768 !< Integer grid number for rotated equidistant cylindrical E-stagger grid (grib2)
   integer, public, parameter :: ROT_EQUID_CYLIND_B_GRID_ID_GRIB2 = 32769 !< Integer grid number for rotated equidistant cylindrical B-stagger grid (grib2)
 
-  logical, public, save :: ncep_post_arakawa=.false. !< Use ncep_post-compatible version of init_grib2() for non-E Arakawa grids
+  logical, public, save :: ncep_post_arakawa=.false. !< Use ncep_post/wgrib2-compatible version of init_grib2() for non-E Arakawa grids (enable with use_ncep_post_arakawa())
 
   private
   public :: ip_grid

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -176,7 +176,7 @@ module ip_grid_mod
 contains
 
   !> Enables ncep_post/wgrib2-compatible non-E Arakawa grib2 grids
-  !> by setting ncep_post_arakawa=.true.
+  !> by setting `ncep_post_arakawa=.true.`.
   !> This subroutine should be called prior to init_grib2().
   !>
   !> @author Alex Richert

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -28,10 +28,13 @@ module ip_grid_mod
   integer, public, parameter :: ROT_EQUID_CYLIND_E_GRID_ID_GRIB2 = 32768 !< Integer grid number for rotated equidistant cylindrical E-stagger grid (grib2)
   integer, public, parameter :: ROT_EQUID_CYLIND_B_GRID_ID_GRIB2 = 32769 !< Integer grid number for rotated equidistant cylindrical B-stagger grid (grib2)
 
+  logical, public, save :: ncep_post_arakawa=.false. !< Use ncep_post-compatible version of init_grib2() for non-E Arakawa grids
+
   private
   public :: ip_grid
   public :: gdswzd_interface
   public :: operator(==)
+  public :: use_ncep_post_arakawa
 
   !> Abstract grid that holds fields and methods common to all grids.
   !! ip_grid is meant to be subclassed when implementing a new grid.
@@ -171,6 +174,12 @@ module ip_grid_mod
   
 
 contains
+
+  subroutine use_ncep_post_arakawa() bind(c)
+    !
+    USE ISO_C_BINDING, ONLY: C_BOOL
+    ncep_post_arakawa = .true.
+  end subroutine use_ncep_post_arakawa
 
   !> Compares two grids.
   !>

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -175,6 +175,12 @@ module ip_grid_mod
 
 contains
 
+  !> Enables ncep_post/wgrib2-compatible non-E Arakawa grib2 grids
+  !> by setting ncep_post_arakawa=.true.
+  !> This subroutine should be called prior to init_grib2().
+  !>
+  !> @author Alex Richert
+  !> @date May 2024
   subroutine use_ncep_post_arakawa() bind(c)
     ncep_post_arakawa = .true.
   end subroutine use_ncep_post_arakawa

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -176,8 +176,6 @@ module ip_grid_mod
 contains
 
   subroutine use_ncep_post_arakawa() bind(c)
-    !
-    USE ISO_C_BINDING, ONLY: C_BOOL
     ncep_post_arakawa = .true.
   end subroutine use_ncep_post_arakawa
 

--- a/src/ip_grid_mod.F90
+++ b/src/ip_grid_mod.F90
@@ -176,7 +176,7 @@ module ip_grid_mod
 contains
 
   !> Enables ncep_post/wgrib2-compatible non-E Arakawa grib2 grids
-  !> by setting `ncep_post_arakawa=.true.`.
+  !> by setting 'ncep_post_arakawa=.true.'.
   !> This subroutine should be called prior to init_grib2().
   !>
   !> @author Alex Richert

--- a/src/ip_rot_equid_cylind_grid_mod.F90
+++ b/src/ip_rot_equid_cylind_grid_mod.F90
@@ -130,13 +130,101 @@ CONTAINS
   end subroutine init_grib1
 
   !> Initializes a Rotated equidistant cylindrical grid given a
-  !> grib2_descriptor object.
+  !> grib2_descriptor object. Call 'use_ncep_post_arakawa()' before
+  !> using this subroutine to use ncep_post-compatible grid definition.
+  !>
+  !> @param[inout] self The grid to initialize
+  !> @param[in] g2_desc A grib2_descriptor
+  !>
+  !> @author Alex Richert @date 2024-MAY-20
+  subroutine init_grib2(self, g2_desc)
+    class(ip_rot_equid_cylind_grid), intent(inout) :: self
+    type(grib2_descriptor), intent(in) :: g2_desc
+
+    if (ncep_post_arakawa) then
+      call init_grib2_ncep_post(self, g2_desc)
+    else
+      call init_grib2_default(self, g2_desc)
+    endif
+
+  end subroutine init_grib2
+
+  !> Initializes a Rotated equidistant cylindrical grid given a
+  !> grib2_descriptor object. Uses template definitions consistent
+  !> with WMO standards.
   !>
   !> @param[inout] self The grid to initialize
   !> @param[in] g2_desc A grib2_descriptor
   !>
   !> @author Gayno @date 2007-NOV-15
-  subroutine init_grib2(self, g2_desc)
+  subroutine init_grib2_default(self, g2_desc)
+    class(ip_rot_equid_cylind_grid), intent(inout) :: self
+    type(grib2_descriptor), intent(in) :: g2_desc
+
+    real(kd) :: rlat1, rlon1, rlat0, rlat2, rlon2, nbd, ebd
+    integer :: iscale
+    integer :: i_offset_odd, i_offset_even, j_offset
+
+    associate(igdtmpl => g2_desc%gdt_tmpl, igdtlen => g2_desc%gdt_len)
+
+      CALL EARTH_RADIUS(IGDTMPL,IGDTLEN,self%rerth,self%eccen_squared)
+
+      I_OFFSET_ODD=MOD(IGDTMPL(19)/8,2)
+      I_OFFSET_EVEN=MOD(IGDTMPL(19)/4,2)
+      J_OFFSET=MOD(IGDTMPL(19)/2,2)
+
+      ISCALE=IGDTMPL(10)*IGDTMPL(11)
+      IF(ISCALE==0) ISCALE=10**6
+
+      RLAT1=FLOAT(IGDTMPL(12))/FLOAT(ISCALE)
+      RLON1=FLOAT(IGDTMPL(13))/FLOAT(ISCALE)
+      RLAT0=FLOAT(IGDTMPL(20))/FLOAT(ISCALE)
+      RLAT0=RLAT0+90.0_KD
+
+      self%RLON0=FLOAT(IGDTMPL(21))/FLOAT(ISCALE)
+
+      RLAT2=FLOAT(IGDTMPL(15))/FLOAT(ISCALE)
+      RLON2=FLOAT(IGDTMPL(16))/FLOAT(ISCALE)
+
+      self%IROT=MOD(IGDTMPL(14)/8,2)
+      self%IM=IGDTMPL(8)
+      self%JM=IGDTMPL(9)
+
+      self%SLAT0=SIN(RLAT0/DPR)
+      self%CLAT0=COS(RLAT0/DPR)
+
+      self%WBD=RLON1
+      IF (self%WBD > 180.0) self%WBD = self%WBD - 360.0
+      self%SBD=RLAT1
+
+      NBD=RLAT2
+      EBD=RLON2
+
+      self%DLATS=(NBD-self%SBD)/FLOAT(self%JM-1)
+      self%DLONS=(EBD-self%WBD)/FLOAT(self%IM-1)
+
+      IF(I_OFFSET_ODD==1) self%WBD=self%WBD+(0.5_KD*self%DLONS)
+      IF(J_OFFSET==1) self%SBD=self%SBD+(0.5_KD*self%DLATS)
+
+      self%iwrap = 0
+      self%jwrap1 = 0
+      self%jwrap2 = 0
+      self%kscan = 0
+      self%nscan = mod(igdtmpl(19) / 32, 2)
+      self%nscan_field_pos = self%nscan
+    end associate
+  end subroutine init_grib2_default
+
+  !> Initializes a Rotated equidistant cylindrical grid given a
+  !> grib2_descriptor object. Uses template number definitions in
+  !> a manner compatible with wgrib2 and ncep_post, which is based
+  !> on grib1.
+  !>
+  !> @param[inout] self The grid to initialize
+  !> @param[in] g2_desc A grib2_descriptor
+  !>
+  !> @author Alex Richert, George Gayno @date 2024-MAY-20
+  subroutine init_grib2_ncep_post(self, g2_desc)
     class(ip_rot_equid_cylind_grid), intent(inout) :: self
     type(grib2_descriptor), intent(in) :: g2_desc
 
@@ -159,7 +247,6 @@ CONTAINS
       RLAT1=FLOAT(IGDTMPL(12))/FLOAT(ISCALE)
       RLON1=FLOAT(IGDTMPL(13))/FLOAT(ISCALE)
       RLAT0=FLOAT(IGDTMPL(15))/FLOAT(ISCALE)
-!      RLAT0=RLAT0+90.0_KD
 
       self%RLON0=FLOAT(IGDTMPL(16))/FLOAT(ISCALE)
 
@@ -211,7 +298,7 @@ CONTAINS
       self%nscan = mod(igdtmpl(19) / 32, 2)
       self%nscan_field_pos = self%nscan
     end associate
-  end subroutine init_grib2
+  end subroutine init_grib2_ncep_post
 
   !> GDS wizard for rotated equidistant cylindrical.
   !>

--- a/src/ip_rot_equid_cylind_grid_mod.F90
+++ b/src/ip_rot_equid_cylind_grid_mod.F90
@@ -141,7 +141,7 @@ CONTAINS
     class(ip_rot_equid_cylind_grid), intent(inout) :: self
     type(grib2_descriptor), intent(in) :: g2_desc
 
-    if (ncep_post_arakawa) then
+    if (ncep_post_arakawa.and.(g2_desc%gdt_num.eq.32769)) then
       call init_grib2_ncep_post(self, g2_desc)
     else
       call init_grib2_default(self, g2_desc)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ foreach(kind ${kinds})
   add_test(test_rotatedB_spectral_vector_grib2_${kind} test_vector_grib2_${kind} 205 4)
   add_test(test_rotatedE_budget_vector_grib2_${kind} test_vector_grib2_${kind} 203 3)
   add_test(test_rotatedB_direct_spectral_vector_grib2_${kind} test_vector_grib2_${kind} 32769 4)
+  add_test(test_rotatedB_direct_ncep_post_spectral_vector_grib2_${kind} test_vector_grib2_${kind} 32769b 4)
   add_test(test_rotatedE_direct_budget_vector_grib2_${kind} test_vector_grib2_${kind} 32768 3)
 
   # vector station point tests

--- a/tests/interp_mod_grib2.F90
+++ b/tests/interp_mod_grib2.F90
@@ -3,6 +3,7 @@
 ! Kyle Gerheiser June, 2021
 
   use ip_mod
+  use ip_grid_mod
   implicit none
 
 contains
@@ -547,13 +548,14 @@ contains
        output_gdtmpl=gdtmpl203
        i_output = output_gdtmpl(8)
        j_output = output_gdtmpl(9)
-    case ('32769')
+    case ('32769','32769b')
        output_gdtnum = 32769
        output_gdtlen = gdtlen205
        allocate(output_gdtmpl(output_gdtlen))
        output_gdtmpl=gdtmpl205
        i_output = output_gdtmpl(8)
        j_output = output_gdtmpl(9)
+       if (trim(grid).eq.'32769b') call use_ncep_post_arakawa()
     case default
        print*,"ERROR: ENTER VALID GRID NUMBER."
        stop 55


### PR DESCRIPTION
My solution for conflicting approaches to deriving the non-E arakawa grids is to include both. wgrib2 and ncep_post (incl. NAM) agree on one definition, which is different from what's in NCEPLIBS-ip currently. With this PR, the user calls `use_ncep_post_arakawa()` (which can be called from C, defined as `void use_ncep_post_arakawa(void)` and called as `use_ncep_post_arakawa()`) to use the wgrib2/ncep_post derivation. The default behavior is to use the current code, so any users of the current definition should be unaffected. This option is only used when gdtn=32769, and can be re-disabled with `unuse_ncep_post_arakawa()`.

Fixes #238 