### PR TITLE
Require CMake>=3.18

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -42,7 +42,7 @@ jobs:
       run: ctest --test-dir ip/build -j2 --verbose --output-on-failure --rerun-failed
 
     - name: run-gcovr
-      run: gcovr -r ip -v  --html-details  --exclude ip/tests --exclude ip/build/CMakeFiles --print-summary -o test-coverage.html
+      run: gcovr -r ip -v  --html-details  --exclude ip/tests --exclude ip/build/CMakeFiles --gcov-ignore-parse-errors --print-summary -o test-coverage.html
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v4

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install doxygen libopenblas-dev
-        python3 -m pip install gcovr
+        python3 -m pip install gcovr==7.2
 
     - name: checkout
       uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
       run: ctest --test-dir ip/build -j2 --verbose --output-on-failure --rerun-failed
 
     - name: run-gcovr
-      run: gcovr -r ip -v  --html-details  --exclude ip/tests --exclude ip/build/CMakeFiles --gcov-ignore-parse-errors --print-summary -o test-coverage.html
+      run: gcovr -r ip -v  --html-details  --exclude ip/tests --exclude ip/build/CMakeFiles --print-summary -o test-coverage.html
 
     - name: upload-test-coverage
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # This is the main CMake file for NCEPLIBS-ip.
 #
-# Mark Potts, Kyle Gerheiser, Eric Engle, Ed Hartnett
-cmake_minimum_required(VERSION 3.15)
+# Mark Potts, Kyle Gerheiser, Eric Engle, Ed Hartnett, Alex Richert
+cmake_minimum_required(VERSION 3.18)
 
 # Get the version from the VERSION file.
 file(STRINGS "VERSION" pVersion)

--- a/spack/package.py
+++ b/spack/package.py
@@ -67,6 +67,7 @@ class Ip(CMakePackage):
     depends_on("sp precision=d", when="@4.1:4 precision=d")
     depends_on("sp precision=8", when="@4.1:4 precision=8")
     depends_on("lapack", when="@5.1:")
+    depends_on("cmake@3.18:", when="@5.1:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
LAPACK::LAPACK target is only available in cmake 3.18.0+.

Fixes #258 