### PR TITLE
add label for slow-running (rotatedB) code tests

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -46,4 +46,4 @@ jobs:
         ls -l ~/install/lib
     
     - name: test
-      run: ctest --test-dir ip/build --parallel 2 --verbose --output-on-failure --rerun-failed
+      run: ctest --test-dir ip/build -LE SLOW_TEST --parallel 2 --verbose --output-on-failure --rerun-failed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=/path/to/install /path/to/NCEPLIBS-ip
 make -j2
-make test # (or ctest --verbose)
+make test # or 'ctest --verbose'; use 'ctest -LE SLOW_TEST' to skip long-running tests
 make install
 ```
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -182,6 +182,19 @@ foreach(kind ${kinds})
   add_test(test_rotatedB_spectral_vector_grib1_${kind} test_vector_grib1_${kind} 205 4)
   add_test(test_rotatedE_budget_vector_grib1_${kind} test_vector_grib1_${kind} 203 3)
 
+  set(slowtests
+    "test_rotatedB_spectral_vector_grib1"
+    "test_rotatedB_spectral_scalar_grib1"
+    "test_rotatedB_spectral_vector_grib2"
+    "test_rotatedB_direct_spectral_vector_grib2"
+    "test_rotatedB_direct_ncep_post_spectral_vector_grib2"
+    "test_rotatedB_spectral_scalar_grib2"
+  )
+
+  foreach(slowtest IN LISTS slowtests)
+    set_tests_properties("${slowtest}_${kind}" PROPERTIES LABELS "SLOW_TEST")
+  endforeach()
+
   # sp tests
   create_sp_test(test_ncpus ${kind} 0.3)
   create_sp_test(test_splaplac ${kind} 0.3)


### PR DESCRIPTION
This PR adds a CTest label SLOW_TEST to slow-running tests (which in practice are all the rotatedB tests). Those tests can be skipped by invoking `ctest -LE SLOW_TEST`.

Fixes #266