### PR TITLE
make openmp and lapack link libs targets private

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -12,6 +12,11 @@ on:
     branches:
     - develop
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Intel:
     runs-on: ubuntu-latest

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -12,6 +12,11 @@ on:
     branches:
     - develop
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Linux:
     runs-on: ubuntu-24.04

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -12,6 +12,11 @@ on:
     branches:
     - develop
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   MacOS:
     runs-on: macos-latest

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
 
     - name: "Build Spack package"
-      uses: NOAA-EMC/ci-test-spack-package@test
+      uses: NOAA-EMC/ci-test-spack-package@develop
       with:
         package-name: ip
         package-variants: ${{ matrix.config.variants }} ${{ matrix.config.extrapkgs }}

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -30,13 +30,12 @@ jobs:
       run: sudo apt install libopenblas-serial-dev
 
     - name: "Build Spack package"
-      uses: NOAA-EMC/ci-test-spack-package@develop
+      uses: NOAA-EMC/ci-test-spack-package@test
       with:
         package-name: ip
         package-variants: ${{ matrix.variants }} ${{ matrix.variants == '+openmp +shared +pic precision=d' && 'grib-util@develop +tests ^g2c@develop +utils +build_v2_api ^g2@3.5:' || '' }}
         custom-recipe: spack/package.py
         spack-compiler: gcc
-        spack-externals: gmake cmake openblas
         repo-cache-key-suffix: ${{ matrix.os }}-${{ matrix.variants }}-1
 
   # This job validates the Spack recipe by making sure each cmake build option is represented

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -13,6 +13,11 @@ on:
     branches:
     - develop
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   developer:
     runs-on: ubuntu-latest

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,9 +69,9 @@ foreach(kind ${kinds})
 
   # Handle OpenMP.
   if(OpenMP_Fortran_FOUND)
-    target_link_libraries(${lib_name} PUBLIC OpenMP::OpenMP_Fortran)
+    target_link_libraries(${lib_name} PRIVATE OpenMP::OpenMP_Fortran)
   endif()
-  target_link_libraries(${lib_name} PUBLIC LAPACK::LAPACK)
+  target_link_libraries(${lib_name} PRIVATE LAPACK::LAPACK)
   
   list(APPEND LIB_TARGETS ${lib_name})
   


### PR DESCRIPTION
This PR changes the target_link_libraries properties for lapack and openmp from PUBLIC to PRIVATE.

Also adding 'concurrency:cancel-in-progress:true' to all the CI workflows.

Fixes #276 
Fixes #234