### PR TITLE
Test updates

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -15,29 +15,47 @@ on:
     branches:
     - develop
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # This job builds with Spack using every combination of variants and runs the CTest suite each time
   Spack:
+    permissions:
+      packages: read
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
-        variants: ["+openmp +shared +pic precision=d", "+openmp ~shared ~pic precision=4", "~openmp ~shared +pic precision=8"]
-    runs-on: ${{ matrix.os }}
+        config:
+        - {
+            os: "ubuntu-24.04",
+            variants: "precision=d +openmp +shared +pic",
+            cache-key: "A",
+            extrapkgs: "grib-util@develop +tests ^g2c@develop +utils +build_v2_api ^g2@3.5:",
+          }
+        - {
+            os: "ubuntu-24.04",
+            variants: "precision=4 +openmp ~shared ~pic",
+            cache-key: "B",
+          }
+        - {
+            os: "ubuntu-24.04",
+            variants: "precision=8 ~openmp ~shared +pic",
+            cache-key: "C",
+          }
+    runs-on: ${{ matrix.config.os }}
 
     steps:
-
-    - name: "Install OpenBLAS"
-      run: sudo apt install libopenblas-serial-dev
 
     - name: "Build Spack package"
       uses: NOAA-EMC/ci-test-spack-package@develop
       with:
         package-name: ip
-        package-variants: ${{ matrix.variants }} ${{ matrix.variants == '+openmp +shared +pic precision=d' && 'grib-util@develop +tests ^g2c@develop +utils +build_v2_api ^g2@3.5:' || '' }}
+        package-variants: ${{ matrix.config.variants }} ${{ matrix.config.extrapkgs }}
         custom-recipe: spack/package.py
         spack-compiler: gcc
-        spack-externals: gmake cmake openblas
-        repo-cache-key-suffix: ${{ matrix.os }}-${{ matrix.variants }}-1
+        repo-cache-key-suffix: ${{ matrix.config.cache-key }}
 
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -24,6 +24,11 @@ therefore requires an external BLAS/LAPACK provider. In practice, this should
 generally be OpenBLAS, which is the [spack-stack](https://github.com/JCSDA/spack-stack)
 BLAS/LAPACK provider.
 
+\note When running unit tests, excluding the CTest label SLOW_TEST may be used
+to avoid slow-running tests (15 seconds to 1 or 2 minutes depending on
+optimization settings). The NO_INPUT_DATA label may be used to run only tests
+which do not require files obtained remotely when FTP_TEST_FILES=ON.
+
 ## Interpolation
 
 ### Interpolation Methods

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -204,4 +204,22 @@ foreach(kind ${kinds})
   create_sp_test(test_fft ${kind} 0.3)
   create_sp_test(test_sptrung ${kind} 0.3)
   create_sp_test(test_sptrungv ${kind} 2)
+
+  # label tests without input data to allow trimmed down unit test runs
+  set(noinputdatatests
+    "test_earth_radius"
+    "test_fft"
+    "test_ipxwafs"
+    "test_ncpus"
+    "test_splaplac"
+    "test_splat"
+    "test_sppad"
+    "test_sptezv"
+    "tst_gdswzd_c_grib1"
+    "tst_gdswzd_c_grib2"
+  )
+  foreach(noinputdatatest IN LISTS noinputdatatests)
+    set_tests_properties("${noinputdatatest}_${kind}" PROPERTIES LABELS "NO_INPUT_DATA")
+  endforeach()
+
 endforeach()

--- a/tests/interp_mod_grib1.F90
+++ b/tests/interp_mod_grib1.F90
@@ -377,8 +377,8 @@ contains
          12191, 12191, 0, 64, 25000, 25000, 0, 0, 0, 0, 0, 0, 255, 180*0/
 
 #if (LSIZE==4)
-    abstol=0.05
-    ntol = 10
+    abstol=0.1
+    ntol = 15
 #else
     abstol=0.0001
     ntol = 0

--- a/tests/interp_mod_grib2.F90
+++ b/tests/interp_mod_grib2.F90
@@ -478,7 +478,7 @@ contains
 
 #if (LSIZE==4)
     abstol=0.05
-    ntol = 10
+    ntol = 15
 #else
     abstol=0.0001
     ntol = 0


### PR DESCRIPTION
This PR adds a CTest label for tests not requiring input data for users who don't want to bother downloading the FTP files. It also fixes the problem of a couple _4 tests failing on account of numerical precision issues by slightly easing the tolerance in the _4 case.

Fixes #277 
Fixes #250 
Partially addresses #216 
Fixes #213