### PR TITLE
Add CDash workflow

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -46,7 +46,7 @@ jobs:
     - name: build
       run: |
         sudo apt install libopenblas-serial-dev
-        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
+        if [ ! -f testfiles.tgz ]; then wget --no-verbose https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
         cmake -S ip -B ip/build -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=OFF -DBUILD_8=ON -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz
         cmake --build ip/build --parallel 2 --verbose
     

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -53,7 +53,7 @@ jobs:
     - name: build
       run: |
         sudo apt install libopenblas-serial-dev
-        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
+        if [ ! -f testfiles.tgz ]; then wget --no-verbose https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
         export CC=gcc-${{ matrix.gcc-version }} ; export FC=gfortran-${{ matrix.gcc-version }}
         cmake -S ip -B ip/build -DCMAKE_PREFIX_PATH="~/" -DOPENMP=${{ matrix.openmp }} ${{ matrix.options }} -DCMAKE_INSTALL_PREFIX=~/install -DBLA_VENDOR=OpenBLAS -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz
         cmake --build ip/build --parallel 2 --verbose

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: build
       run: |
-        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
+        if [ ! -f testfiles.tgz ]; then wget --no-verbose https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
         cmake -S ip -B ip/build -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} -DCMAKE_INSTALL_PREFIX=~/install -DBUILD_8=ON -DCMAKE_BUILD_TYPE=Debug -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz
         cmake --build ip/build --parallel 2 --verbose
         cmake --install ip/build

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - develop
-    - add_cdash
 
 jobs:
   cdash:

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -25,9 +25,10 @@ jobs:
     - name: Install dependencies & handle test files
       run: |
         sudo apt-get install libopenblas-dev
-        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
+        if [ ! -f testfiles.tgz ]; then wget --no-verbose https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
 
     - name: CDash
       uses: NOAA-EMC/ci-cdash@develop
       with:
         extra-cmake-options: -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz
+        extra-ctest-options: -LE SLOW_TEST

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -1,0 +1,24 @@
+name: cdash
+on:
+  push:
+    branches:
+    - develop
+    - add_cdash
+
+jobs:
+  cdash:
+    runs-on: ubuntu-latest
+
+    env:
+      FC: gfortran
+      CC: gcc
+      CDASH_TOKEN: ${{ secrets.CDASH_TOKEN }}
+
+    steps:
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libopenblas-dev
+
+    - name: CDash
+      uses: NOAA-EMC/ci-cdash@develop

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -25,10 +25,9 @@ jobs:
     - name: Install dependencies & handle test files
       run: |
         sudo apt-get install libopenblas-dev
-        if [ ! -f testfiles.tgz ]; then wget --no-verbose https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
+        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
 
     - name: CDash
       uses: NOAA-EMC/ci-cdash@develop
       with:
         extra-cmake-options: -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz
-        extra-ctest-options: -LE SLOW_TEST

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -16,9 +16,18 @@ jobs:
 
     steps:
 
-    - name: Install dependencies
+    - name: Cache test files
+      uses: actions/cache@v4
+      with:
+        path: testfiles.tgz
+        key: NCEPLIBS-ip-test-files-1
+
+    - name: Install dependencies & handle test files
       run: |
         sudo apt-get install libopenblas-dev
+        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
 
     - name: CDash
       uses: NOAA-EMC/ci-cdash@develop
+      with:
+        extra-cmake-options: -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: build
       run: |
-        if [ ! -f testfiles.tgz ]; then wget https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
+        if [ ! -f testfiles.tgz ]; then wget --no-verbose https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz -O testfiles.tgz ; fi
         cmake -S ip -B ip/build -DENABLE_DOCS=YES -DOPENMP=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address" -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON -DBUILD_8=ON -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz
         cmake --build ip/build --parallel 2 --verbose
     

--- a/spack/package.py
+++ b/spack/package.py
@@ -121,5 +121,5 @@ class Ip(CMakePackage):
 
     @when("@4:")
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")

--- a/spack/package.py
+++ b/spack/package.py
@@ -18,6 +18,7 @@ class Ip(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
+    version("5.3.0", sha256="17dfcb52bab58d3f1bcbbdda5e76430020d963097139e1ba240bfc5fb5c5a5d1")
     version("5.2.0", sha256="2f7b44abcf24e448855f57d107db55d3d58cbc271164ba083491d0c07a7ea3d0")
     version("5.1.0", sha256="5279f11f4c12db68ece74cec392b7a2a6b5166bc505877289f34cc3149779619")
     version("5.0.0", sha256="54b2987bd4f94adc1f7595d2a384e646019c22d163bcd30840a916a6abd7df71")
@@ -59,6 +60,8 @@ class Ip(CMakePackage):
         description="Build deprecated spectral interpolation functions",
         when="@5.0:",
     )
+    # JCSDA repo only:
+    variant("alltests", default=False, description="Run full unit test suite", when="@5.3:")
 
     conflicts("+shared ~pic")
 
@@ -70,12 +73,31 @@ class Ip(CMakePackage):
     depends_on("lapack", when="@5.1:")
     depends_on("cmake@3.18:", when="@5.1:", type="build")
 
+    # JCSDA repo only:
+    resource(
+        name="ip-test-data-20241230.tgz",
+        url="https://ftp.emc.ncep.noaa.gov/static_files/public/NCEPLIBS-ip/ip-test-data-20241230.tgz",
+        sha256="3a33309f2451699c255717ffa60645f6c6862201a234b7bb77a340f5f5d345a8",
+        placement="testfiles",
+        expand=False,
+        when="+alltests",
+    )
+
     def cmake_args(self):
         args = [
             self.define_from_variant("OPENMP", "openmp"),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-            self.define("FTP_TEST_FILES", self.run_tests),
         ]
+
+        # JCSDA repo only:
+        if self.spec.satisfies("+alltests"):
+            args.append(self.define("FTP_TEST_FILES", self.run_tests))
+            args.append(
+                self.define(
+                    "TEST_FILES_CACHE",
+                    join_path(self.stage.source_path, "testfiles/ip-test-data-20241230.tgz"),
+                )
+            )
 
         if self.spec.satisfies("@4:"):
             args.append(self.define("BUILD_TESTING", self.run_tests))
@@ -93,7 +115,7 @@ class Ip(CMakePackage):
         if self.spec.satisfies("@5:"):
             args.append(self.define_from_variant("BUILD_DEPRECATED", "deprecated"))
 
-        if self.spec.satisfies("+lapack"):
+        if self.spec.satisfies("@5.1:"):
             # Use the LAPACK provider set by Spack even if the compiler supports native BLAS
             bla_vendors = {"openblas": "OpenBLAS"}
             lapack_provider = self.spec["lapack"].name
@@ -122,4 +144,8 @@ class Ip(CMakePackage):
     @when("@4:")
     def check(self):
         with working_dir(self.build_directory):
-            make("test")
+            # JCSDA repo only; main Spack repo should just use `ctest("-L", "NO_INPUT_DATA")`
+            if self.spec.satisfies("+alltests") or self.spec.satisfies("@:5.2"):
+                ctest()
+            else:
+                ctest("-L", "NO_INPUT_DATA")


### PR DESCRIPTION
This PR adds a CI job that creates CDash info and pushes it to https://my.cdash.org/index.php?project=NCEPLIBS-ip each time a commit is merged into develop. Also some other CI updates and updates to package.py to minimize the Spack CI runtime (will no longer use test files).

Working test: https://github.com/AlexanderRichert-NOAA/NCEPLIBS-ip/actions/runs/14366910589/job/40281959190