### PR TITLE
LLM code reviews; make CMake deps optional for downstream projects

### DIFF
--- a/.github/workflows/llm-code-review.yml
+++ b/.github/workflows/llm-code-review.yml
@@ -1,0 +1,34 @@
+# This workflow provides reviews for code modifications using AI (large
+# language models) based on the file diffs between the head of develop and the
+# branch for which this workflow is run. This workflow can be triggered
+# manually ('workflow_dispatch' target). Depending how you wish to configure
+# your API keys, you may run this workflow either in your own fork (assuming
+# this workflow exists in the default branch of your forked repository) or in
+# the parent repository. The code reviews are uploaded to a GitHub Actions
+# artifact whose URL can be found at the end of the workflow run.
+#
+# For more documentation, including a list of the available models for
+# producing code reviews and instructions for securely configuring API keys,
+# see https://github.com/NOAA-EMC/ci-llm-code-review.
+#
+# ***DO NOT PUT API KEYS DIRECTLY IN THIS FILE*** (always use GitHub secrets)
+#
+# Alex Richert, Apr 2025
+
+name: llm-code-review
+on: [workflow_dispatch]
+
+jobs:
+  llm-code-review:
+    runs-on: ubuntu-latest
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+      GH_API_KEY: ${{ secrets.GH_API_KEY }}
+
+    steps:
+
+    - name: "Code review"
+      uses: NOAA-EMC/ci-llm-code-review@develop
+      with:
+        api-key-variable: GH_API_KEY

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -9,12 +9,14 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 include(CMakeFindDependencyMacro)
 
-if(@OPENMP@)
-  find_dependency(OpenMP COMPONENTS Fortran)
-endif()
+if(NOT SKIP_NCEPLIBS_DEPS STREQUAL NO)
+  if(@OPENMP@)
+    find_dependency(OpenMP COMPONENTS Fortran)
+  endif()
 
-set(BLA_VENDOR @BLA_VENDOR@)
-find_dependency(LAPACK)
+  set(BLA_VENDOR @BLA_VENDOR@)
+  find_dependency(LAPACK)
+endif()
 
 # The target name needs to be one that's built, even if the dependent
 # build does not use that version.


### PR DESCRIPTION
This PR:
 - adds a new Actions workflow for obtaining AI/large language model-based reviews based on diffs between the develop branch and the branch for which the workflow is run (i.e., the one that contains code changes to be reviews); and
 - adds new logic to cmake/PackageConfig.cmake.in to allow downstream CMake projects to do their own handling of package dependencies rather than automatically propagating them (default behavior is unchanged, i.e., by default dependencies are automatically provided when a downstream project calls `find_package(ip)`).

Here is the artifact containing code reviews for this PR: https://github.com/AlexanderRichert-NOAA/NCEPLIBS-ip/actions/runs/14743490008/artifacts/3034014166

Part of https://github.com/NOAA-EMC/NCEPLIBS/issues/224
Fixes #294