### PR TITLE
cmake/PackageConfig.cmake.in: fix typo

### DIFF
--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -9,7 +9,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 include(CMakeFindDependencyMacro)
 
-if(NOT SKIP_NCEPLIBS_DEPS STREQUAL NO)
+if(NOT SKIP_NCEPLIBS_DEPS)
   if(@OPENMP@)
     find_dependency(OpenMP COMPONENTS Fortran)
   endif()


### PR DESCRIPTION
This PR fixes a typo and simplifies the logic in cmake/PackageConfig.cmake.in. By default, dependencies are loaded, but a downstream project can set SKIP_NCEPLIBS_DEPS to ON to disable loading dependencies.