### PR TITLE
enable Werror for developer.yml (exclude maybe-uninit, for now)

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -21,8 +21,8 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-12
-      CC: gcc-12
+      FC: gfortran
+      CC: gcc
     strategy:
       matrix:
         openmp: [ ON, OFF ]

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -21,8 +21,8 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran
-      CC: gcc
+      FC: gfortran-13
+      CC: gcc-13
     strategy:
       matrix:
         openmp: [ ON, OFF ]

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -50,8 +50,8 @@ jobs:
         cmake -S ip -B ip/build \
           -DENABLE_DOCS=YES \
           -DOPENMP=ON \
-          -DCMAKE_Fortran_FLAGS="--coverage -fsanitize=address" \
-          -DCMAKE_C_FLAGS="-fsanitize=address" \
+          -DCMAKE_Fortran_FLAGS="--coverage -fsanitize=address -Werror -Wno-error=maybe-uninitialized" \
+          -DCMAKE_C_FLAGS="-fsanitize=address -Werror" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_SHARED_LIBS=ON -DBUILD_8=ON \
           -DFTP_TEST_FILES=ON -DTEST_FILES_CACHE=$GITHUB_WORKSPACE/testfiles.tgz

--- a/tests/tst_gdswzd_grib1.c
+++ b/tests/tst_gdswzd_grib1.c
@@ -79,8 +79,12 @@ int main()
          xlat, ylon, ylat, area);
 
   int expextedPointsReturned = 50451;
-  
+
+#if(LSIZE==8)
+  printf("Points returned from gdswzd = %ld \n", nret);
+#else
   printf("Points returned from gdswzd = %d \n", nret);
+#endif
   printf(" Expected points returned    = %d \n\n", expextedPointsReturned);
   
   if (nret != expextedPointsReturned) {

--- a/tests/tst_gdswzd_grib2.c
+++ b/tests/tst_gdswzd_grib2.c
@@ -94,8 +94,11 @@ int main()
          crot, srot, xlon, xlat, ylon, ylat, area);
 
   int expextedPointsReturned = 50451;
-  
+#if(LSIZE==8)
+  printf("Points returned from gdswzd = %ld \n", nret);
+#else
   printf("Points returned from gdswzd = %d \n", nret);
+#endif
   printf(" Expected points returned    = %d \n\n", expextedPointsReturned);
   
   if (nret != expextedPointsReturned) {


### PR DESCRIPTION
This PR adds `-Werror -Wno-error=maybe-uninitialized` to the Fortran flags and `-Werror` to the C flags in developer.yml CI. The maybe uninitialized warnings will be captured in a separate issue.