### PR TITLE
CMakeLists.txt: warn for unsupported compilers instead of fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(LLVMFlang)$")
   set(fortran_d_flags "-fdefault-real-8")
   set(fortran_8_flags "-fdefault-integer-8 -fdefault-real-8")
 else()
-  message(FATAL_ERROR "Unsupported Fortran compiler '${CMAKE_Fortran_COMPILER_ID}'")
+  message(WARNING "Unsupported Fortran compiler '${CMAKE_Fortran_COMPILER_ID}'")
 endif()
 
 # This is the source code directiroy.


### PR DESCRIPTION
### Description
This PR updates the root CMakeLists.txt to emit a warning when the detected Fortran compiler is unsupported, rather than failing.

### Issues addressed
none

### Generative AI disclosure (required)
> [!IMPORTANT]
> _If LLM/generative AI tools were used to create any of the changes in this PR, please update the placeholder text below. If your AI-generated code has been reviewed and validated by **NWS staff** (including yourself), check the box, otherwise only update the AI tool name and leave the box unchecked until the PR is reviewed._
- [ ] **[Insert AI tool name]** was used to assist with developing this code. The code has been reviewed, edited, and validated by NWS staff.
- [x] No generative AI tools were used to develop any of the code in this PR.
