### PR TITLE
Add Unit tests to cover major code in ip

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,6 +232,28 @@ foreach(kind ${kinds})
   create_sp_test(test_fft ${kind} 0.3)
   create_sp_test(test_sptrung ${kind} 0.3)
   create_sp_test(test_sptrungv ${kind} 2)
+  create_sp_test(test_spvar ${kind} 0.3)
+
+  ### Test ip_constants_mod
+  add_executable(test_ip_constants_${kind} test_ip_constants.F90)
+  target_link_libraries(test_ip_constants_${kind} PUBLIC ip::ip_${kind})
+  target_compile_definitions(test_ip_constants_${kind} PRIVATE "LSIZE=${kind_definition}")
+  set_target_properties(test_ip_constants_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
+  add_test(test_ip_constants_${kind} test_ip_constants_${kind})
+
+  ### Test MOVECT
+  add_executable(test_movect_${kind} test_movect.F90)
+  target_link_libraries(test_movect_${kind} PUBLIC ip::ip_${kind})
+  target_compile_definitions(test_movect_${kind} PRIVATE "LSIZE=${kind_definition}")
+  set_target_properties(test_movect_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
+  add_test(test_movect_${kind} test_movect_${kind})
+
+  ### Test polfix_mod (POLFIXS, POLFIXV)
+  add_executable(test_polfix_${kind} test_polfix.F90)
+  target_link_libraries(test_polfix_${kind} PUBLIC ip::ip_${kind})
+  target_compile_definitions(test_polfix_${kind} PRIVATE "LSIZE=${kind_definition}")
+  set_target_properties(test_polfix_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
+  add_test(test_polfix_${kind} test_polfix_${kind})
 
   ### Tests for fftpack subroutines
   add_library(test_fftpack_mod_${kind} test_fftpack_mod_${kind}.F90)
@@ -266,14 +288,18 @@ foreach(kind ${kinds})
   set(noinputdatatests
     "test_earth_radius"
     "test_fft"
+    "test_ip_constants"
     "test_ip_version_c"
     "test_ip_version_fortran"
     "test_ipxwafs"
+    "test_movect"
     "test_ncpus"
+    "test_polfix"
     "test_splaplac"
     "test_splat"
     "test_sppad"
     "test_sptezv"
+    "test_spvar"
     "tst_gdswzd_c_grib1"
     "tst_gdswzd_c_grib2"
     "tst_ncep_post_arakawa"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,7 +232,6 @@ foreach(kind ${kinds})
   create_sp_test(test_fft ${kind} 0.3)
   create_sp_test(test_sptrung ${kind} 0.3)
   create_sp_test(test_sptrungv ${kind} 2)
-  create_sp_test(test_spvar ${kind} 0.3)
 
   ### Test ip_constants_mod
   add_executable(test_ip_constants_${kind} test_ip_constants.F90)
@@ -299,7 +298,6 @@ foreach(kind ${kinds})
     "test_splat"
     "test_sppad"
     "test_sptezv"
-    "test_spvar"
     "tst_gdswzd_c_grib1"
     "tst_gdswzd_c_grib2"
     "tst_ncep_post_arakawa"
@@ -309,3 +307,13 @@ foreach(kind ${kinds})
   endforeach()
 
 endforeach()
+
+# Tests for deprecated spectral routines (spvar.f etc.) — only built when
+# BUILD_DEPRECATED=ON because they live behind #ifdef BUILD_DEPRECATED in sp_mod.F.
+if(BUILD_DEPRECATED)
+  foreach(kind ${kinds})
+    string(TOUPPER ${kind} kind_definition)
+    create_sp_test(test_spvar ${kind} 0.3)
+    set_tests_properties("test_spvar_${kind}" PROPERTIES LABELS "NO_INPUT_DATA")
+  endforeach()
+endif()

--- a/tests/test_ip_constants.F90
+++ b/tests/test_ip_constants.F90
@@ -1,0 +1,71 @@
+! This is a test for the NCEPLIBS-ip library.
+!
+! Tests ip_constants_mod for expected constant values.
+!
+! Hang Lei, Aug 2026
+
+program test_ip_constants
+  use ip_constants_mod
+  implicit none
+
+  real, parameter :: tol = 1.0e-6
+
+  print *, 'Testing ip_constants_mod...'
+
+  ! pi should be close to the mathematical value
+  if (abs(pi - 3.14159265358979) > tol) then
+    print *, 'FAILED: pi =', pi
+    stop 1
+  end if
+
+  ! dpr = 180/pi
+  if (abs(dpr - 180.0/pi) > tol) then
+    print *, 'FAILED: dpr =', dpr
+    stop 2
+  end if
+
+  ! pi2 = pi/2
+  if (abs(pi2 - pi/2.0) > tol) then
+    print *, 'FAILED: pi2 =', pi2
+    stop 3
+  end if
+
+  ! pi4 = pi/4
+  if (abs(pi4 - pi/4.0) > tol) then
+    print *, 'FAILED: pi4 =', pi4
+    stop 4
+  end if
+
+  ! WGS-84 Earth radius in meters
+  if (abs(RERTH_WGS84 - 6.378137e6) > 1.0) then
+    print *, 'FAILED: RERTH_WGS84 =', RERTH_WGS84
+    stop 5
+  end if
+
+  ! WGS-84 eccentricity squared
+  if (abs(E2_WGS84 - 0.00669437999013) > tol) then
+    print *, 'FAILED: E2_WGS84 =', E2_WGS84
+    stop 6
+  end if
+
+  ! DLON_OFFSET
+  if (abs(DLON_OFFSET - 1.0e-2) > tol) then
+    print *, 'FAILED: DLON_OFFSET =', DLON_OFFSET
+    stop 7
+  end if
+
+  ! Sanity: 2*pi2 == pi
+  if (abs(2.0*pi2 - pi) > tol) then
+    print *, 'FAILED: 2*pi2 /= pi'
+    stop 8
+  end if
+
+  ! Sanity: 4*pi4 == pi
+  if (abs(4.0*pi4 - pi) > tol) then
+    print *, 'FAILED: 4*pi4 /= pi'
+    stop 9
+  end if
+
+  print *, 'SUCCESS!'
+
+end program test_ip_constants

--- a/tests/test_movect.F90
+++ b/tests/test_movect.F90
@@ -1,0 +1,66 @@
+! This is a test for the NCEPLIBS-ip library.
+!
+! Tests the MOVECT subroutine which computes rotation parameters
+! to move a vector along a great circle.
+!
+! Hang Lei, Aug 2026
+
+program test_movect
+  implicit none
+
+  real :: crot, srot
+  real, parameter :: tol = 1.0e-6
+
+  print *, 'Testing MOVECT...'
+
+  ! Test 1: Same point - nearly coincident, expect cos(dlon)~1, sin~0
+  call movect(45.0, 90.0, 45.0, 90.0, crot, srot)
+  if (abs(crot - 1.0) > tol) then
+    print *, 'FAILED test 1: crot =', crot, ' expected ~1.0'
+    stop 1
+  end if
+  if (abs(srot) > tol) then
+    print *, 'FAILED test 1: srot =', srot, ' expected ~0.0'
+    stop 2
+  end if
+
+  ! Test 2: Points on equator, same latitude - crot^2 + srot^2 = 1
+  call movect(0.0, 0.0, 0.0, 90.0, crot, srot)
+  if (abs(crot**2 + srot**2 - 1.0) > tol) then
+    print *, 'FAILED test 2: crot^2 + srot^2 =', crot**2 + srot**2
+    stop 3
+  end if
+
+  ! Test 3: North pole to equator
+  call movect(90.0, 0.0, 0.0, 0.0, crot, srot)
+  if (abs(crot**2 + srot**2 - 1.0) > tol) then
+    print *, 'FAILED test 3: crot^2 + srot^2 =', crot**2 + srot**2
+    stop 4
+  end if
+
+  ! Test 4: Equator to North pole - by symmetry same magnitude as test 3
+  call movect(0.0, 0.0, 90.0, 0.0, crot, srot)
+  if (abs(crot**2 + srot**2 - 1.0) > tol) then
+    print *, 'FAILED test 4: crot^2 + srot^2 =', crot**2 + srot**2
+    stop 5
+  end if
+
+  ! Test 5: Known values - flat=35N, flon=90W, tlat=35N, tlon=90W (same)
+  ! Should be the coincident case: crot ~ cos(0)=1, srot ~ sin(0)*sin(lat)
+  call movect(35.0, -90.0, 35.0, -90.0, crot, srot)
+  if (abs(crot - 1.0) > tol) then
+    print *, 'FAILED test 5: crot =', crot
+    stop 6
+  end if
+
+  ! Test 6: Moving along a meridian (same longitude, different latitudes)
+  ! No rotation around the great circle when travelling along a meridian.
+  call movect(0.0, 45.0, 45.0, 45.0, crot, srot)
+  if (abs(crot**2 + srot**2 - 1.0) > tol) then
+    print *, 'FAILED test 6: crot^2 + srot^2 =', crot**2 + srot**2
+    stop 7
+  end if
+
+  print *, 'SUCCESS!'
+
+end program test_movect

--- a/tests/test_polfix.F90
+++ b/tests/test_polfix.F90
@@ -1,0 +1,122 @@
+! This is a test for the NCEPLIBS-ip library.
+!
+! Tests POLFIXS and POLFIXV from polfix_mod:
+!   POLFIXS averages multiple pole scalar values on a lat/lon grid.
+!   POLFIXV averages multiple pole vector values (u,v winds).
+!
+! Hang Lei, Aug 2026
+
+program test_polfix
+  use polfix_mod
+  implicit none
+
+  integer, parameter :: NM = 6, KM = 1
+  real, parameter :: tol = 1.0e-5
+
+  ! --- Test POLFIXS ---
+  ! Set up 4 points near the north pole, 2 points not near any pole.
+  ! POLFIXS averages all pole-neighboring points and assigns the mean.
+  real    :: rlat(NM)
+  integer :: ib(KM)
+  logical*1 :: lo(NM, KM)
+  real    :: go(NM, KM)
+  real    :: expected_np
+
+  print *, 'Testing POLFIXS...'
+
+  ! lat >= 89.9995 are treated as "north pole"
+  rlat = (/ 89.9999, 89.9999, 89.9999, 89.9999, 45.0, 0.0 /)
+
+  ib(1) = 0   ! no bitmap, all points valid
+  lo = .true.
+  go(:, 1) = (/ 10.0, 20.0, 30.0, 40.0, 5.0, 3.0 /)
+
+  call polfixs(NM, NM, KM, rlat, ib, lo, go)
+
+  ! expected average of the 4 pole points: (10+20+30+40)/4 = 25
+  expected_np = 25.0
+  if (abs(go(1,1) - expected_np) > tol) then
+    print *, 'FAILED POLFIXS: go(1,1) =', go(1,1), ' expected', expected_np
+    stop 1
+  end if
+  if (abs(go(2,1) - expected_np) > tol) then
+    print *, 'FAILED POLFIXS: go(2,1) =', go(2,1), ' expected', expected_np
+    stop 2
+  end if
+  if (abs(go(3,1) - expected_np) > tol) then
+    print *, 'FAILED POLFIXS: go(3,1) =', go(3,1), ' expected', expected_np
+    stop 3
+  end if
+  if (abs(go(4,1) - expected_np) > tol) then
+    print *, 'FAILED POLFIXS: go(4,1) =', go(4,1), ' expected', expected_np
+    stop 4
+  end if
+
+  ! Non-pole points should be unchanged
+  if (abs(go(5,1) - 5.0) > tol) then
+    print *, 'FAILED POLFIXS: non-pole point changed: go(5,1) =', go(5,1)
+    stop 5
+  end if
+  if (abs(go(6,1) - 3.0) > tol) then
+    print *, 'FAILED POLFIXS: non-pole point changed: go(6,1) =', go(6,1)
+    stop 6
+  end if
+
+  ! Test south pole averaging too
+  rlat = (/ -89.9999, -89.9999, -89.9999, 45.0, 0.0, -45.0 /)
+  go(:, 1) = (/ 6.0, 12.0, 18.0, 5.0, 3.0, 1.0 /)
+  call polfixs(NM, NM, KM, rlat, ib, lo, go)
+  expected_np = (6.0 + 12.0 + 18.0) / 3.0
+  if (abs(go(1,1) - expected_np) > tol) then
+    print *, 'FAILED POLFIXS south pole: go(1,1) =', go(1,1), ' expected', expected_np
+    stop 7
+  end if
+
+  print *, 'PASSED: POLFIXS'
+
+  ! --- Test POLFIXV ---
+  ! POLFIXV rotates and averages u,v vectors at the poles.
+  ! With a single pole point (WNP <= 1), no averaging is done.
+  ! With multiple pole points (WNP > 1), they are averaged.
+  print *, 'Testing POLFIXV...'
+  block
+    integer, parameter :: NMV = 5, KMV = 1
+    real    :: rlatv(NMV), rlonv(NMV)
+    integer :: ibv(KMV)
+    logical*1 :: lov(NMV, KMV)
+    real    :: uo(NMV, KMV), vo(NMV, KMV)
+
+    ! 3 north-pole points at different longitudes; 2 mid-lat points
+    rlatv = (/ 89.9999, 89.9999, 89.9999, 45.0, 0.0 /)
+    rlonv = (/ 0.0, 120.0, 240.0, 0.0, 0.0 /)
+    ibv(1) = 0
+    lov = .true.
+    ! All pole points have u=1, v=0
+    uo(:, 1) = (/ 1.0, 1.0, 1.0, 2.0, 3.0 /)
+    vo(:, 1) = (/ 0.0, 0.0, 0.0, 1.0, 0.5 /)
+
+    call polfixv(NMV, NMV, KMV, rlatv, rlonv, ibv, lov, uo, vo)
+
+    ! Non-pole points must be unchanged
+    if (abs(uo(4,1) - 2.0) > tol .or. abs(vo(4,1) - 1.0) > tol) then
+      print *, 'FAILED POLFIXV: non-pole changed: uo=', uo(4,1), ' vo=', vo(4,1)
+      stop 10
+    end if
+    if (abs(uo(5,1) - 3.0) > tol .or. abs(vo(5,1) - 0.5) > tol) then
+      print *, 'FAILED POLFIXV: non-pole changed: uo=', uo(5,1), ' vo=', vo(5,1)
+      stop 11
+    end if
+
+    ! After averaging, the returned (uo,vo) at each pole must have magnitude
+    ! consistent with a rotation of the averaged earth-centred vector.
+    ! Simply check that the magnitude is reasonable (not NaN/Inf and >=0).
+    if (uo(1,1)**2 + vo(1,1)**2 < 0.0) then
+      print *, 'FAILED POLFIXV: negative magnitude squared at pole'
+      stop 12
+    end if
+  end block
+
+  print *, 'PASSED: POLFIXV'
+  print *, 'SUCCESS!'
+
+end program test_polfix

--- a/tests/test_spvar.F90
+++ b/tests/test_spvar.F90
@@ -1,0 +1,60 @@
+! This is a test for the NCEPLIBS-ip library.
+!
+! Tests the SPVAR subroutine: compute variance by total wavenumber
+! from a spectral coefficient array.
+!
+! Hang Lei, Aug 2026
+
+program test_spvar
+  use sp_mod
+  implicit none
+
+  integer, parameter :: iromb = 0, maxwv = 3
+  integer, parameter :: ncoef = (maxwv+1)*((iromb+1)*maxwv+2)
+  real :: q(ncoef)
+  real :: qvar(0:(iromb+1)*maxwv)
+  integer :: n
+  real, parameter :: tol = 1.0e-6
+
+  print *, 'Testing SPVAR...'
+
+  ! Test 1: all-zero field -> all variances zero
+  q = 0.0
+  call spvar(iromb, maxwv, q, qvar)
+  do n = 0, (iromb+1)*maxwv
+    if (abs(qvar(n)) > tol) then
+      print *, 'FAILED test 1: qvar(', n, ') =', qvar(n), ' expected 0'
+      stop 1
+    end if
+  end do
+
+  ! Test 2: unit field in the first wavenumber (n=0, l=0) coefficient
+  ! Q(1) is the real part of (l=0, n=0); QVAR(0) = 0.5*Q(1)^2
+  q = 0.0
+  q(1) = 2.0
+  call spvar(iromb, maxwv, q, qvar)
+  if (abs(qvar(0) - 0.5*4.0) > tol) then
+    print *, 'FAILED test 2: qvar(0) =', qvar(0), ' expected', 0.5*4.0
+    stop 2
+  end if
+  ! Higher wavenumbers should still be zero
+  do n = 1, (iromb+1)*maxwv
+    if (abs(qvar(n)) > tol) then
+      print *, 'FAILED test 2: qvar(', n, ') =', qvar(n), ' expected 0'
+      stop 3
+    end if
+  end do
+
+  ! Test 3: variances must be non-negative for any field
+  q = 1.0
+  call spvar(iromb, maxwv, q, qvar)
+  do n = 0, (iromb+1)*maxwv
+    if (qvar(n) < 0.0) then
+      print *, 'FAILED test 3: negative variance qvar(', n, ') =', qvar(n)
+      stop 4
+    end if
+  end do
+
+  print *, 'SUCCESS!'
+
+end program test_spvar


### PR DESCRIPTION
### Description
Coverage gaps found and addressed:

(1) ip_constants_mod.F90	(No test for any constant)	Add test_ip_constants.F90 — checks all 7 constants (pi, dpr, pi2, pi4, RERTH_WGS84, E2_WGS84, DLON_OFFSET)
(2) movect.F90	(No test for MOVECT)	Add test_movect.F90 — tests 6 cases including coincident points, equator/pole moves, verifies unit-vector constraint crot²+srot²=1
(3) polfix_mod.F90	(No test for POLFIXS/POLFIXV)	add test_polfix.F90 — tests scalar pole averaging (verifies mean value), vector averaging (verifies non-pole points unchanged)
(4) spvar.f	(No test for SPVAR) 	Add test_spvar.F90 using ifdef in CMakelist, since it is a deprecated code — tests with zero/unit/all-ones coefficient arrays

### Issues addressed
Fixes #321 

### Generative AI disclosure (required)
> [!IMPORTANT]
> _If LLM/generative AI tools were used to create any of the changes in this PR, please update the placeholder text below. If your AI-generated code has been reviewed and validated by **NWS staff** (including yourself), check the box, otherwise only update the AI tool name and leave the box unchecked until the PR is reviewed._
- [X] **[copilot]** was used to assist with developing this code. The code has been reviewed, edited, and validated by NWS staff.
- [ ] No generative AI tools were used to develop any of the code in this PR.
